### PR TITLE
fix stream errors not crashing the process

### DIFF
--- a/lib/log.js
+++ b/lib/log.js
@@ -1,4 +1,4 @@
-import { pipeline, Transform } from 'node:stream'
+import { Transform } from 'node:stream'
 import rfs from 'rotating-file-stream'
 import { basename, dirname } from 'node:path'
 
@@ -27,6 +27,6 @@ export const createLogStream = path => {
     path: dirname(path),
     history: `.${basename(path)}.history`
   })
-  pipeline(tr, ws, console.error)
+  tr.pipe(ws)
   return tr
 }

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -1,5 +1,5 @@
 import { createLogStream } from './log.js'
-import { Transform, pipeline } from 'node:stream'
+import { Transform } from 'node:stream'
 import { writePoint } from './telemetry.js'
 import { Point } from '@influxdata/influxdb-client'
 
@@ -9,13 +9,10 @@ import { Point } from '@influxdata/influxdb-client'
 // - Serializes JSON
 export const createMetricsStream = metricsPath => {
   const deduplicateStream = new DeduplicateStream()
-  pipeline(
-    deduplicateStream,
-    new TelemetryStream(),
-    new SerializeStream(),
-    createLogStream(metricsPath),
-    console.error
-  )
+  deduplicateStream
+    .pipe(new TelemetryStream())
+    .pipe(new SerializeStream())
+    .pipe(createLogStream(metricsPath))
   return deduplicateStream
 }
 


### PR DESCRIPTION
Since this is a CLI, we want stream `"error"` events to crash the process, rather than just logging to stderr