### PR TITLE
Rework `ROOT_DIR` to `CACHE_ROOT` and `STATE_ROOT`. Closes #76

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,13 +47,13 @@ Station Core is configured using environment variables (see
 
 The following configuration options are shared by all Station commands:
 
-- `$CACHE_ROOT`_(string; optional)_: Station stores logs and module state in
-  this directory. Defaults to
+- `$CACHE_ROOT`_(string; optional)_: Station stores module caches in this
+  directory. Defaults to
   - Linux: `${XDG_STATE_HOME:-~/.local/cache}/filecoin-station-core`
   - macOS: `~/Library/Caches/app.filstation.core`
   - Windows: `%LOCALAPPDATA%/Filecoin Station Core/Cache`
-- `$STATE_ROOT`_(string; optional)_: Station stores module caches in this
-  directory. Defaults to
+- `$STATE_ROOT`_(string; optional)_: Station stores logs and module state in
+  this directory. Defaults to
   - Linux: `${XDG_STATE_HOME:-~/.local/state}/filecoin-station-core`
   - macOS: `~/Library/Application Support/app.filstation.core`
   - Windows: `%LOCALAPPDATA%/Filecoin Station Core/State`

--- a/README.md
+++ b/README.md
@@ -47,11 +47,16 @@ Station Core is configured using environment variables (see
 
 The following configuration options are shared by all Station commands:
 
-- `$ROOT_DIR`_(string; optional)_: Station stores logs and module state in this
+- `$CACHE_ROOT`_(string; optional)_: Station stores logs and module state in
+  this directory. Defaults to
+  - Linux: `${XDG_STATE_HOME:-~/.local/cache}/filecoin-station-core`
+  - macOS: `~/Library/Caches/app.filstation.core`
+  - Windows: `%LOCALAPPDATA%/Filecoin Station Core/Cache`
+- `$STATE_ROOT`_(string; optional)_: Station stores module caches in this
   directory. Defaults to
   - Linux: `${XDG_STATE_HOME:-~/.local/state}/filecoin-station-core`
   - macOS: `~/Library/Application Support/app.filstation.core`
-  - Windows: `%LOCALAPPDATA%/Filecoin Station Core`
+  - Windows: `%LOCALAPPDATA%/Filecoin Station Core/State`
 
 ## Commands
 

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ Station Core is configured using environment variables (see
 
 The following configuration options are shared by all Station commands:
 
-- `$CACHE_ROOT`_(string; optional)_: Station stores module caches in this
-  directory. Defaults to
+- `$CACHE_ROOT`_(string; optional)_: Station store temporary files (e.g. cached 
+data) in this directory. Defaults to
   - Linux: `${XDG_STATE_HOME:-~/.local/cache}/filecoin-station-core`
   - macOS: `~/Library/Caches/app.filstation.core`
   - Windows: `%LOCALAPPDATA%/Filecoin Station Core/Cache`

--- a/README.md
+++ b/README.md
@@ -47,8 +47,8 @@ Station Core is configured using environment variables (see
 
 The following configuration options are shared by all Station commands:
 
-- `$CACHE_ROOT`_(string; optional)_: Station store temporary files (e.g. cached 
-data) in this directory. Defaults to
+- `$CACHE_ROOT`_(string; optional)_: Station store temporary files (e.g. cached
+  data) in this directory. Defaults to
   - Linux: `${XDG_STATE_HOME:-~/.local/cache}/filecoin-station-core`
   - macOS: `~/Library/Caches/app.filstation.core`
   - Windows: `%LOCALAPPDATA%/Filecoin Station Core/Cache`

--- a/bin/station.js
+++ b/bin/station.js
@@ -19,7 +19,8 @@ Sentry.init({
   tracesSampleRate: 0.1
 })
 
-await fs.mkdir(join(paths.moduleStorage, 'saturn-L2-node'), { recursive: true })
+await fs.mkdir(join(paths.moduleCache, 'saturn-L2-node'), { recursive: true })
+await fs.mkdir(join(paths.moduleState, 'saturn-L2-node'), { recursive: true })
 await fs.mkdir(paths.moduleLogs, { recursive: true })
 await maybeCreateMetricsFile()
 await maybeCreateActivityFile()

--- a/commands/station.js
+++ b/commands/station.js
@@ -29,7 +29,7 @@ export const station = async () => {
 
   await saturnNode.start({
     FIL_WALLET_ADDRESS,
-    storagePath: join(paths.moduleStorage, 'saturn-L2-node'),
+    storagePath: join(paths.moduleCache, 'saturn-L2-node'),
     binariesPath: paths.moduleBinaries,
     metricsStream: createMetricsStream(paths.metrics),
     activityStream: createActivityStream('Saturn'),

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -4,45 +4,55 @@ import { fileURLToPath } from 'node:url'
 import assert from 'node:assert'
 
 const {
-  ROOT_DIR,
+  CACHE_ROOT,
+  STATE_ROOT,
   LOCALAPPDATA,
+  XDG_CACHE_HOME = join(homedir(), '.local', 'cache'),
   XDG_STATE_HOME = join(homedir(), '.local', 'state')
 } = process.env
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), '..')
 
-export const getPaths = root => ({
+export const getPaths = (cacheRoot, stateRoot) => ({
   repoRoot,
-  metrics: join(root, 'logs', 'metrics.log'),
-  activity: join(root, 'logs', 'activity.log'),
-  moduleStorage: join(root, 'modules'),
-  moduleLogs: join(root, 'logs', 'modules'),
-  allLogs: join(root, 'logs', 'all.log'),
+  metrics: join(stateRoot, 'logs', 'metrics.log'),
+  activity: join(stateRoot, 'logs', 'activity.log'),
+  moduleCache: join(cacheRoot, 'modules'),
+  moduleState: join(stateRoot, 'modules'),
+  moduleLogs: join(stateRoot, 'logs', 'modules'),
+  allLogs: join(stateRoot, 'logs', 'all.log'),
   moduleBinaries: join(repoRoot, 'modules'),
-  lockFile: join(root, '.lock')
+  lockFile: join(stateRoot, '.lock')
 })
 
-const getRoot = () => {
-  if (ROOT_DIR) {
-    return ROOT_DIR
-  }
-
+const getRootDirs = () => {
   switch (platform()) {
     case 'darwin':
-      return join(
-        homedir(),
-        'Library',
-        'Application Support',
-        'app.filstation.core'
-      )
+      return [
+        CACHE_ROOT ||
+          join(homedir(), 'Library', 'Caches', 'app.filstation.core'),
+        STATE_ROOT ||
+          join(
+            homedir(),
+            'Library',
+            'Application Support',
+            'app.filstation.core'
+          )
+      ]
     case 'win32':
       assert(LOCALAPPDATA, '%LOCALAPPDATA% required')
-      return join(LOCALAPPDATA, 'Filecoin Station Core')
+      return [
+        CACHE_ROOT || join(LOCALAPPDATA, 'Filecoin Station Core', 'Cache'),
+        STATE_ROOT || join(LOCALAPPDATA, 'Filecoin Station Core', 'State')
+      ]
     case 'linux':
-      return join(XDG_STATE_HOME, 'filecoin-station-core')
+      return [
+        CACHE_ROOT || join(XDG_CACHE_HOME, 'filecoin-station-core'),
+        STATE_ROOT || join(XDG_STATE_HOME, 'filecoin-station-core')
+      ]
     default:
       throw new Error(`Unsupported platform: ${platform()}`)
   }
 }
 
-export const paths = getPaths(getRoot())
+export const paths = getPaths(...getRootDirs())


### PR DESCRIPTION
Closes #76.

Use `CACHE_ROOT` for Saturn for now.