### PR TITLE
Add `--json` to `station activity`

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,24 @@ $ station activity
 [3/14/2023, 10:23:18 AM] INFO  Saturn Node is online and connected to 9 peers
 ```
 
+```bash
+$ station activity --json
+[
+  {
+    "date": "2023-04-05T11:26:41.000Z",
+    "type": "info",
+    "source": "Saturn",
+    "message": "Saturn Node is online and connected to 1 peers"
+  },
+  {
+    "date": "2023-04-05T11:26:46.000Z",
+    "type": "info",
+    "source": "Saturn",
+    "message": "Saturn Node is online and connected to 9 peers"
+  }
+]
+```
+
 Follow activity:
 
 ```bash
@@ -116,6 +134,12 @@ $ station activity --follow
 [3/14/2023, 10:23:14 AM] INFO  Saturn Node is online and connected to 1 peers
 [3/14/2023, 10:23:18 AM] INFO  Saturn Node is online and connected to 9 peers
 ...
+```
+
+```bash
+$ station activity --follow --json
+{"date":"2023-04-05T11:26:41.000Z","type":"info","source":"Saturn","message":"Saturn Node is online and connected to 1 peers"}
+{"date":"2023-04-05T11:26:46.000Z","type":"info","source":"Saturn","message":"Saturn Node is online and connected to 9 peers"}
 ```
 
 ### `$ station logs <module>`

--- a/bin/station.js
+++ b/bin/station.js
@@ -30,7 +30,16 @@ yargs(hideBin(process.argv))
   .usage('Usage: $0 <command> [options]')
   .command('$0', 'Start Station', () => {}, commands.station)
   .command('metrics', 'Show metrics', () => {}, commands.metrics)
-  .commands('activity', 'Show activity log', () => {}, commands.activity)
+  .commands(
+    'activity',
+    'Show activity log',
+    yargs => yargs.option('json', {
+      alias: 'j',
+      type: 'boolean',
+      description: 'Output JSON'
+    }),
+    commands.activity
+  )
   .command('logs [module]', 'Show module logs', () => {}, commands.logs)
   .choices('module', ['saturn-l2-node'])
   .command('events', 'Events stream', () => {}, commands.events)

--- a/commands/activity.js
+++ b/commands/activity.js
@@ -5,16 +5,25 @@ const formatActivityObject = ({ type, message, date }) => {
   return formatLog(`${type.toUpperCase().padEnd(5)} ${message}`, date)
 }
 
-export const activity = async ({ follow }) => {
+export const activity = async ({ follow, json }) => {
   if (follow) {
     for await (const obj of followActivity()) {
-      process.stdout.write(formatActivityObject(obj))
+      if (json) {
+        process.stdout.write(JSON.stringify(obj) + '\n')
+      } else {
+        process.stdout.write(formatActivityObject(obj))
+      }
     }
   } else {
-    process.stdout.write(
-      (await getActivity())
-        .map(obj => formatActivityObject(obj))
-        .join('')
-    )
+    const activity = await getActivity()
+    if (json) {
+      console.log(JSON.stringify(activity, 0, 2))
+    } else {
+      process.stdout.write(
+        activity
+          .map(obj => formatActivityObject(obj))
+          .join('')
+      )
+    }
   }
 }


### PR DESCRIPTION
This is for Station Desktop to load the initial Activity feed, without needing to store it itself