### PR TITLE
ci: start Docker image and test output

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,2 +1,3 @@
 node_modules
+modules
 npm-debug.log

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,13 +54,13 @@ jobs:
           cache-from: type=registry,ref=ghcr.io/filecoin-station/core
           cache-to: type=inline
 
-      - name: Build Docker image for other platforms
-        uses: docker/build-push-action@v4
-        with:
-          context: .
-          platforms: linux/arm64
-          cache-from: type=registry,ref=ghcr.io/filecoin-station/core
-          cache-to: type=inline
+      # - name: Build Docker image for other platforms
+      #   uses: docker/build-push-action@v4
+      #   with:
+      #     context: .
+      #     platforms: linux/arm64
+      #     cache-from: type=registry,ref=ghcr.io/filecoin-station/core
+      #     cache-to: type=inline
 
       - name: Start Station Core container
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -54,13 +54,13 @@ jobs:
           cache-from: type=registry,ref=ghcr.io/filecoin-station/core
           cache-to: type=inline
 
-      # - name: Build Docker image for other platforms
-      #   uses: docker/build-push-action@v4
-      #   with:
-      #     context: .
-      #     platforms: linux/arm64
-      #     cache-from: type=registry,ref=ghcr.io/filecoin-station/core
-      #     cache-to: type=inline
+      - name: Build Docker image for other platforms
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/arm64
+          cache-from: type=registry,ref=ghcr.io/filecoin-station/core
+          cache-to: type=inline
 
       - name: Start Station Core container
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,12 +74,10 @@ jobs:
 
       - name: Print station activity
         run: |
-          sleep 5 # Wait for Station modules to start
+          sleep 10 # Wait for Station modules to start
           docker exec station bin/station.js activity
 
       - name: Check | Saturn started
         run: docker exec station bin/station.js activity | grep "Saturn module started"
 
-      - name: Check | Zinnia started
-        run: docker exec station bin/station.js activity | grep "Module Runtime started"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,11 +72,12 @@ jobs:
         env:
           IMAGEID: ${{ steps.docker_build.outputs.imageid }}
 
-      - name: Verify container activity
-        run: |
-          docker exec station bin/station.js activity
-          LOGS=$(docker exec station bin/station.js activity)
-          echo $LOGS
-          echo $LOGS | grep "Saturn module started"
-          echo $LOGS | grep "Module Runtime started"
+      - name: Print station activity
+        run: docker exec station bin/station.js activity
+
+      - name: Check | Saturn started
+        run: docker exec station bin/station.js activity | grep "Saturn module started"
+
+      - name: Check | Zinnia started
+        run: docker exec station bin/station.js activity | grep "Module Runtime started"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,7 +73,9 @@ jobs:
           IMAGEID: ${{ steps.docker_build.outputs.imageid }}
 
       - name: Print station activity
-        run: docker exec station bin/station.js activity
+        run: |
+          sleep 5 # Wait for Station modules to start
+          docker exec station bin/station.js activity
 
       - name: Check | Saturn started
         run: docker exec station bin/station.js activity | grep "Saturn module started"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,7 @@ jobs:
 
       - name: Verify container activity
         run: |
+          docker exec station bin/station.js activity
           LOGS=$(docker exec station bin/station.js activity)
           echo $LOGS
           echo $LOGS | grep "Saturn module started"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,5 +79,3 @@ jobs:
 
       - name: Check | Saturn started
         run: docker exec station bin/station.js activity | grep "Saturn module started"
-
-

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,11 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v2
+        with:
+          platforms: "arm64"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
 
@@ -46,6 +51,14 @@ jobs:
           context: .
           load: true
           tags: core-test
+          cache-from: type=registry,ref=ghcr.io/filecoin-station/core
+          cache-to: type=inline
+
+      - name: Build Docker image for other platforms
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          platforms: linux/arm64
           cache-from: type=registry,ref=ghcr.io/filecoin-station/core
           cache-to: type=inline
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,3 +17,52 @@ jobs:
       - run: npm run test:lint
         if: matrix.os != 'windows-latest'
       - run: npm run test:unit
+
+  docker:
+    name: Build and test Docker
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
+    env:
+      REGISTRY: ghcr.io
+
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: docker/login-action@v2
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Build and load Docker image
+        id: docker_build
+        uses: docker/build-push-action@v4
+        with:
+          context: .
+          load: true
+          tags: core-test
+          cache-from: type=registry,ref=ghcr.io/filecoin-station/core
+          cache-to: type=inline
+
+      - name: Start Station Core container
+        run: |
+         docker run \
+           --name station \
+           --detach \
+           --env FIL_WALLET_ADDRESS=f1abjxfbp274xpdqcpuaykwkfb43omjotacm2p3za \
+           $IMAGEID
+        env:
+          IMAGEID: ${{ steps.docker_build.outputs.imageid }}
+
+      - name: Verify container activity
+        run: |
+          LOGS=$(docker exec station bin/station.js activity)
+          echo $LOGS
+          echo $LOGS | grep "Saturn module started"
+          echo $LOGS | grep "Module Runtime started"
+

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,22 +1,22 @@
 name: CI
 on: [push]
 jobs:
-  # build:
-  #   runs-on: ${{ matrix.os }}
-  #   strategy:
-  #     matrix:
-  #       os: [macos-latest, ubuntu-latest, windows-latest]
-  #       node: ['16', '18', '19']
-  #   steps:
-  #     - uses: actions/checkout@v3
-  #     - uses: actions/setup-node@v3
-  #       with:
-  #         node-version: ${{ matrix.node }}
-  #     - run: npm ci --omit=dev
-  #     - run: npm ci
-  #     - run: npm run test:lint
-  #       if: matrix.os != 'windows-latest'
-  #     - run: npm run test:unit
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [macos-latest, ubuntu-latest, windows-latest]
+        node: ['16', '18', '19']
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node }}
+      - run: npm ci --omit=dev
+      - run: npm ci
+      - run: npm run test:lint
+        if: matrix.os != 'windows-latest'
+      - run: npm run test:unit
 
   docker:
     name: Build and test Docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,22 +1,22 @@
 name: CI
 on: [push]
 jobs:
-  build:
-    runs-on: ${{ matrix.os }}
-    strategy:
-      matrix:
-        os: [macos-latest, ubuntu-latest, windows-latest]
-        node: ['16', '18', '19']
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3
-        with:
-          node-version: ${{ matrix.node }}
-      - run: npm ci --omit=dev
-      - run: npm ci
-      - run: npm run test:lint
-        if: matrix.os != 'windows-latest'
-      - run: npm run test:unit
+  # build:
+  #   runs-on: ${{ matrix.os }}
+  #   strategy:
+  #     matrix:
+  #       os: [macos-latest, ubuntu-latest, windows-latest]
+  #       node: ['16', '18', '19']
+  #   steps:
+  #     - uses: actions/checkout@v3
+  #     - uses: actions/setup-node@v3
+  #       with:
+  #         node-version: ${{ matrix.node }}
+  #     - run: npm ci --omit=dev
+  #     - run: npm ci
+  #     - run: npm run test:lint
+  #       if: matrix.os != 'windows-latest'
+  #     - run: npm run test:unit
 
   docker:
     name: Build and test Docker

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -2,7 +2,6 @@ name: Docker build
 on:
   push:
     tags: ["*"]
-    branches: ["*"]
 
 env:
   REGISTRY: ghcr.io
@@ -35,11 +34,11 @@ jobs:
       - uses: martinbeentjes/npm-get-version-action@main
         id: package-version
 
-      - name: Build and optionally push Docker image
+      - name: Build and push Docker image
         uses: docker/build-push-action@v4
         with:
           context: .
-          push: ${{ startsWith(github.ref, 'refs/tags/v') }}
+          push: true
           tags: |
             ghcr.io/filecoin-station/core
             ghcr.io/filecoin-station/core:${{ steps.package-version.outputs.current-version }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:18-alpine
 LABEL org.opencontainers.image.source https://github.com/filecoin-station/core
+USER node
 WORKDIR /usr/src/app
 COPY . .
 RUN npm ci --omit=dev
-USER node
 CMD [ "./bin/station.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,8 +2,6 @@ FROM node:18-alpine
 LABEL org.opencontainers.image.source https://github.com/filecoin-station/core
 USER node
 WORKDIR /usr/src/app
-COPY package*.json ./
-COPY scripts/post-install.js ./scripts/
-RUN npm ci --omit=dev
 COPY . .
+RUN npm ci --omit=dev
 CMD [ "./bin/station.js" ]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM node:18-alpine
 LABEL org.opencontainers.image.source https://github.com/filecoin-station/core
-USER node
 WORKDIR /usr/src/app
 COPY . .
 RUN npm ci --omit=dev
+USER node
 CMD [ "./bin/station.js" ]

--- a/bin/station.js
+++ b/bin/station.js
@@ -61,7 +61,7 @@ yargs(hideBin(process.argv))
     commands.activity
   )
   .command('logs [module]', 'Show module logs', () => {}, commands.logs)
-  .choices('module', ['saturn-l2-node'])
+  .choices('module', modules)
   .version(`${pkg.name}: ${pkg.version}`)
   .alias('v', 'version')
   .alias('h', 'help')

--- a/lib/saturn-node.js
+++ b/lib/saturn-node.js
@@ -5,7 +5,7 @@ import { fetch } from 'undici'
 import * as Sentry from '@sentry/node'
 import { installBinaryModule, getBinaryModuleExecutable } from './modules.js'
 
-const DIST_TAG = 'v0.5.0'
+const DIST_TAG = 'v0.5.1'
 
 export async function install () {
   await installBinaryModule({

--- a/lib/saturn-node.js
+++ b/lib/saturn-node.js
@@ -9,10 +9,10 @@ const DIST_TAG = 'v0.5.1'
 
 export async function install () {
   await installBinaryModule({
-    module: 'saturn-l2-node',
+    module: 'saturn-L2-node',
     repo: 'filecoin-saturn/L2-node',
     distTag: DIST_TAG,
-    executable: 'L2-node',
+    executable: 'saturn-L2-node',
     arch: platform() === 'darwin' ? 'x64' : arch(),
     targets: [
       { platform: 'darwin', arch: 'x64', asset: 'L2-node_Darwin_x86_64.zip' },
@@ -36,8 +36,8 @@ async function start ({
 
   const childProcess = execa(
     getBinaryModuleExecutable({
-      module: 'saturn-l2-node',
-      executable: 'L2-node'
+      module: 'saturn-L2-node',
+      executable: 'saturn-L2-node'
     }), {
       env: {
         ROOT_DIR: storagePath,

--- a/test/metrics.js
+++ b/test/metrics.js
@@ -51,12 +51,12 @@ describe('Metrics', () => {
       { recursive: true }
     )
     await fs.writeFile(
-      join(getPaths(CACHE_ROOT, STATE_ROOT).metrics, 'saturn-l2-node.log'),
+      join(getPaths(CACHE_ROOT, STATE_ROOT).metrics, 'saturn-L2-node.log'),
       '[date] {"totalJobsCompleted":1,"totalEarnings":"2"}\n'
     )
     const { stdout } = await execa(
       station,
-      ['metrics', 'saturn-l2-node'],
+      ['metrics', 'saturn-L2-node'],
       { env: { CACHE_ROOT, STATE_ROOT } }
     )
     assert.deepStrictEqual(


### PR DESCRIPTION
- Fix Dockerfile to accommodate the latest changes and build a working Docker image again.
- Upgrade Saturn L2 Node to version [v0.5.1](https://github.com/filecoin-saturn/L2-node/releases/tag/v0.5.1)
- Add a new section to our CI workflow to build the Docker image, run it and check the activity log to verify that all modules have started.
- Partially revert 6bbd34c57fd7f07c5ce1324686ac9fd59f21c7a7 (#91). The "Docker" workflow is executed for release builds only; the pull requests are tested using the newly added section in the "CI" workflow.

More information on the users and permissions in the Node Docker images:
https://github.com/nodejs/docker-node/issues/740#issuecomment-458545074

Ideally, we would re-use the same workflow step to build the Docker image for release and for CI testing, just changing the output for the image(s). Unfortunately, that's not possible right now.
- `docker buildx` supports only single output, see https://github.com/moby/buildkit/issues/1555.
- The `docker` output type (used by `load: true` of the GitHub Action we are using) does not support multi-platform images, see https://docs.docker.com/engine/reference/commandline/buildx_build/#docker.