### PR TITLE
telemetry: add core id

### DIFF
--- a/lib/telemetry.js
+++ b/lib/telemetry.js
@@ -37,14 +37,14 @@ setInterval(() => {
 
 const startPingLoop = () => {
   assert(FIL_WALLET_ADDRESS)
-  const coreId = randomUUID()
+  const processUUID = randomUUID()
   return setInterval(() => {
     const point = new Point('ping')
     point.stringField(
       'wallet',
       createHash('sha256').update(FIL_WALLET_ADDRESS).digest('hex')
     )
-    point.stringField('core_id', coreId)
+    point.stringField('process_uuid', processUUID)
     point.stringField('version', pkg.version)
     point.tag('station', 'core')
     point.tag('platform', platform())

--- a/lib/telemetry.js
+++ b/lib/telemetry.js
@@ -1,7 +1,7 @@
 'use strict'
 
 const { InfluxDB, Point } = require('@influxdata/influxdb-client')
-const { createHash } = require('node:crypto')
+const { createHash, randomUUID } = require('node:crypto')
 const Sentry = require('@sentry/node')
 const assert = require('node:assert')
 const { platform, arch } = require('node:os')
@@ -37,12 +37,14 @@ setInterval(() => {
 
 const startPingLoop = () => {
   assert(FIL_WALLET_ADDRESS)
+  const coreId = randomUUID()
   return setInterval(() => {
     const point = new Point('ping')
     point.stringField(
       'wallet',
       createHash('sha256').update(FIL_WALLET_ADDRESS).digest('hex')
     )
+    point.stringField('core_id', coreId)
     point.stringField('version', pkg.version)
     point.tag('station', 'core')
     point.tag('platform', platform())


### PR DESCRIPTION
Add per process core random id. Without this, we can't tell how many core instances are running - only how many distinct wallets are configured.

A core process will get a random id when it starts. Since you can run multiple cores on one machine, a machine id isn't feasible.