### PR TITLE
telemetry: add tag `deployment_type`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,4 +4,5 @@ USER node
 WORKDIR /usr/src/app
 COPY . .
 RUN npm ci --omit=dev
+ENV DEPLOYMENT_TYPE=docker
 CMD [ "./bin/station.js" ]

--- a/lib/telemetry.js
+++ b/lib/telemetry.js
@@ -7,7 +7,7 @@ const assert = require('node:assert')
 const { platform, arch } = require('node:os')
 const pkg = require('../package.json')
 
-const { FIL_WALLET_ADDRESS } = process.env
+const { FIL_WALLET_ADDRESS, RUNNING_IN_STATION_DESKTOP } = process.env
 
 const client = new InfluxDB({
   url: 'https://eu-central-1-1.aws.cloud2.influxdata.com',
@@ -47,6 +47,10 @@ const startPingLoop = () => {
     point.tag('station', 'core')
     point.tag('platform', platform())
     point.tag('arch', arch())
+    point.tag(
+      'running_in_station_desktop',
+      String(['1', 'true'].includes(RUNNING_IN_STATION_DESKTOP))
+    )
     writeClient.writePoint(point)
   }, 10_000)
 }

--- a/lib/telemetry.js
+++ b/lib/telemetry.js
@@ -7,7 +7,13 @@ const assert = require('node:assert')
 const { platform, arch } = require('node:os')
 const pkg = require('../package.json')
 
-const { FIL_WALLET_ADDRESS, RUNNING_IN_STATION_DESKTOP } = process.env
+const { FIL_WALLET_ADDRESS, DEPLOYMENT_TYPE = 'cli' } = process.env
+
+const validDeploymentTypes = ['cli', 'docker', 'station-desktop']
+assert(
+  validDeploymentTypes.includes(DEPLOYMENT_TYPE),
+  `Invalid DEPLOYMENT_TYPE: ${DEPLOYMENT_TYPE}. Options: ${validDeploymentTypes.join(', ')}`
+)
 
 const client = new InfluxDB({
   url: 'https://eu-central-1-1.aws.cloud2.influxdata.com',
@@ -49,10 +55,7 @@ const startPingLoop = () => {
     point.tag('station', 'core')
     point.tag('platform', platform())
     point.tag('arch', arch())
-    point.tag(
-      'running_in_station_desktop',
-      String(['1', 'true'].includes(RUNNING_IN_STATION_DESKTOP))
-    )
+    point.tag('deployment_type', DEPLOYMENT_TYPE)
     writeClient.writePoint(point)
   }, 10_000)
 }


### PR DESCRIPTION
Without this we can't tell from a telemetry line whether a `wallet` hash identifies a destination wallet or the Station wallet.

Related: https://github.com/filecoin-station/desktop/pull/714