### PR TITLE
update `bacalhau` to `v1.0.2`

### DIFF
--- a/lib/bacalhau.js
+++ b/lib/bacalhau.js
@@ -4,7 +4,7 @@ import { fetch } from 'undici'
 import Sentry from '@sentry/node'
 import { installBinaryModule, getBinaryModuleExecutable } from './modules.js'
 
-const DIST_TAG = 'v1.0.0'
+const DIST_TAG = 'v1.0.2'
 
 export async function install () {
   await installBinaryModule({


### PR DESCRIPTION
This produces a new error, I'm asking in Slack whether this can be ignored or needs a configuration change:

```
error unmarshalling libp2p payload: executor: unknown engine type 'Language' NodeID=QmX7qxUX
```