### PR TITLE
telemetry: also search err.code

### DIFF
--- a/lib/telemetry.js
+++ b/lib/telemetry.js
@@ -5,7 +5,6 @@ import assert from 'node:assert'
 import { platform, arch } from 'node:os'
 import fs from 'node:fs/promises'
 import * as paths from './paths.js'
-import { inspect } from 'node:util'
 
 const { FIL_WALLET_ADDRESS, DEPLOYMENT_TYPE = 'cli' } = process.env
 
@@ -35,9 +34,9 @@ const unactionableErrors =
 
 setInterval(() => {
   writeClient.flush().catch(err => {
-    if (!unactionableErrors.test(inspect(err))) {
-      Sentry.captureException(err)
-    }
+    if (unactionableErrors.test(String(err))) return
+    if (err?.code && unactionableErrors.test(err.code)) return
+    Sentry.captureException(err)
   })
 }, 5_000).unref()
 

--- a/lib/telemetry.js
+++ b/lib/telemetry.js
@@ -5,6 +5,7 @@ import assert from 'node:assert'
 import { platform, arch } from 'node:os'
 import fs from 'node:fs/promises'
 import * as paths from './paths.js'
+import { inspect } from 'node:util'
 
 const { FIL_WALLET_ADDRESS, DEPLOYMENT_TYPE = 'cli' } = process.env
 
@@ -34,7 +35,7 @@ const unactionableErrors =
 
 setInterval(() => {
   writeClient.flush().catch(err => {
-    if (!unactionableErrors.test(String(err))) {
+    if (!unactionableErrors.test(inspect(err))) {
       Sentry.captureException(err)
     }
   })

--- a/lib/telemetry.js
+++ b/lib/telemetry.js
@@ -34,8 +34,12 @@ const unactionableErrors =
 
 setInterval(() => {
   writeClient.flush().catch(err => {
-    if (unactionableErrors.test(String(err))) return
-    if (err?.code && unactionableErrors.test(err.code)) return
+    if (unactionableErrors.test(String(err))) {
+      return
+    }
+    if (typeof err?.code === 'string' && unactionableErrors.test(err.code)) {
+      return
+    }
     Sentry.captureException(err)
   })
 }, 5_000).unref()


### PR DESCRIPTION
Previously we weren't successfully filtering out errors like ones with `.code = 'ECONNRESET'`, because the `String(err)` only includes the message, no other properties:

```js
> const err = new Error('message')
> err.code = 'ECONNRESET'
> String(err)
> // => Error: message
```

`util.inspect()` fixes this:

```js
> util.inspect(err)
'Error: message\n' +
  '    at REPL22:1:11\n' +
  '    at Script.runInThisContext (node:vm:122:12)\n' +
  '    at REPLServer.defaultEval (node:repl:567:29)\n' +
  '    at bound (node:domain:433:15)\n' +
  '    at REPLServer.runBound [as eval] (node:domain:444:12)\n' +
  '    at REPLServer.onLine (node:repl:897:10)\n' +
  '    at REPLServer.emit (node:events:523:35)\n' +
  '    at REPLServer.emit (node:domain:489:12)\n' +
  '    at [_onLine] [as _onLine] (node:internal/readline/interface:415:12)\n' +
  '    at [_line] [as _line] (node:internal/readline/interface:886:18) {\n' +
  "  code: 'ECONNRESET'\n" +
  '}'
```

A potential downside is that it includes the stack, which could lead to false positives. If we only want to add the `.code` property, this would work as an alternative. @bajtos which do you think is better?

```js
> String(err + err?.code)
'Error: messageECONNRESET
```