### PR TITLE
feat: upgrade Zinnia to v0.13.0

### DIFF
--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -5,7 +5,7 @@ import { installBinaryModule, downloadSourceFiles, getBinaryModuleExecutable } f
 import { moduleBinaries } from './paths.js'
 import os from 'node:os'
 
-const ZINNIA_DIST_TAG = 'v0.12.0'
+const ZINNIA_DIST_TAG = 'v0.13.0'
 const ZINNIA_MODULES = [
   {
     module: 'spark',


### PR DESCRIPTION
Highlights:
- secure Lassie server using authorisation
- change IPFS retrieval timeouts to 1 day

Full release notes:
https://github.com/filecoin-station/zinnia/releases/tag/v0.13.0

Related: https://github.com/filecoin-station/spark/pull/8