### PR TITLE
add restart modules

### DIFF
--- a/commands/station.js
+++ b/commands/station.js
@@ -51,7 +51,7 @@ export const station = async ({ json, experimental }) => {
   })
 
   const modules = [
-    pRetry(() => zinniaRuntime.start({
+    pRetry(() => zinniaRuntime.run({
       FIL_WALLET_ADDRESS,
       STATE_ROOT: join(paths.moduleState, 'zinnia'),
       CACHE_ROOT: join(paths.moduleCache, 'zinnia'),

--- a/commands/station.js
+++ b/commands/station.js
@@ -6,6 +6,7 @@ import * as bacalhau from '../lib/bacalhau.js'
 import fs from 'node:fs/promises'
 import { metrics } from '../lib/metrics.js'
 import { paths } from '../lib/paths.js'
+import pRetry from 'p-retry'
 
 const { FIL_WALLET_ADDRESS } = process.env
 
@@ -50,7 +51,7 @@ export const station = async ({ json, experimental }) => {
   })
 
   const modules = [
-    zinniaRuntime.start({
+    pRetry(() => zinniaRuntime.start({
       FIL_WALLET_ADDRESS,
       STATE_ROOT: join(paths.moduleState, 'zinnia'),
       CACHE_ROOT: join(paths.moduleCache, 'zinnia'),
@@ -64,7 +65,7 @@ export const station = async ({ json, experimental }) => {
         })
       },
       onMetrics: m => metrics.submit('zinnia', m)
-    })
+    }), { retries: 1000 })
   ]
 
   if (experimental) {

--- a/commands/station.js
+++ b/commands/station.js
@@ -69,14 +69,14 @@ export const station = async ({ json, experimental }) => {
   ]
 
   if (experimental) {
-    modules.push(bacalhau.start({
+    modules.push(pRetry(() => bacalhau.run({
       FIL_WALLET_ADDRESS,
       storagePath: join(paths.moduleCache, 'bacalhau'),
       onActivity: activity => {
         activities.submit({ source: 'Bacalhau', ...activity })
       },
       onMetrics: m => metrics.submit('bacalhau', m)
-    }))
+    }), { retries: 1000 }))
   }
 
   await Promise.all(modules)

--- a/lib/bacalhau.js
+++ b/lib/bacalhau.js
@@ -4,6 +4,7 @@ import { fetch } from 'undici'
 import Sentry from '@sentry/node'
 import { installBinaryModule, getBinaryModuleExecutable } from './modules.js'
 import os from 'node:os'
+import { once } from 'node:events'
 
 const DIST_TAG = 'v1.0.3'
 const { TARGET_ARCH = os.arch() } = process.env
@@ -25,7 +26,7 @@ export async function install () {
   })
 }
 
-export async function start ({
+export async function run ({
   FIL_WALLET_ADDRESS,
   storagePath,
   onActivity,
@@ -75,32 +76,13 @@ export async function start ({
 
       const apiMatch = output.match(/^API: (http.*)$/m)
       if (apiMatch) {
-        const apiUrl = apiMatch[1]
-
         childProcess.stdout.off('data', readyHandler)
-        onActivity({ type: 'info', message: 'Bacalhau module started.' })
-        setInterval(() => {
-          updateStats({ apiUrl, onMetrics })
-            .catch(err => {
-              console.error(
-                `Cannot fetch Bacalhau module stats. ${err.stack || err.message || err}`
-              )
-            })
-        }, 1000).unref()
-        resolve()
+        const apiUrl = apiMatch[1]
+        resolve(apiUrl)
       }
     }
     childProcess.stdout.on('data', readyHandler)
     childProcess.catch(reject)
-  })
-
-  childProcess.on('close', code => {
-    console.error(
-      `Bacalhau closed all stdio with code ${code ?? '<no code>'}`
-    )
-    childProcess.stderr.removeAllListeners()
-    childProcess.stdout.removeAllListeners()
-    Sentry.captureException('Bacalhau exited')
   })
 
   childProcess.on('exit', (code, signal) => {
@@ -109,16 +91,44 @@ export async function start ({
     onActivity({ type: 'info', message: msg })
   })
 
-  try {
-    await Promise.race([
-      readyPromise,
-      timers.setTimeout(500)
-    ])
-  } catch (err) {
-    const errorMsg = err instanceof Error ? err.message : '' + err
-    const message = `Cannot start Bacalhau: ${errorMsg}`
-    onActivity({ type: 'error', message })
-  }
+  await Promise.all([
+    (async () => {
+      let apiUrl
+      try {
+        apiUrl = await readyPromise
+      } catch (err) {
+        const errorMsg = err instanceof Error ? err.message : '' + err
+        const message = `Cannot start Bacalhau: ${errorMsg}`
+        onActivity({ type: 'error', message })
+        throw err
+      }
+
+      onActivity({ type: 'info', message: 'Bacalhau module started.' })
+      while (true) {
+        if (
+          childProcess.exitCode !== null ||
+          childProcess.signalCode !== null
+        ) {
+          break
+        }
+        try {
+          await updateStats({ apiUrl, onMetrics })
+        } catch (err) {
+          const errString = err.stack || err.message || err
+          console.error(`Cannot fetch Bacalhau module stats. ${errString}`)
+        }
+        await timers.setTimeout(1000)
+      }
+    })(),
+    (async () => {
+      const [code] = await once(childProcess, 'close')
+      console.error(`Bacalhau closed all stdio with code ${code ?? '<no code>'}`)
+      childProcess.stderr.removeAllListeners()
+      childProcess.stdout.removeAllListeners()
+      Sentry.captureException('Bacalhau exited')
+      throw new Error('Bacalhau exited')
+    })()
+  ])
 }
 
 function handleActivityLogs ({ onActivity, text }) {

--- a/lib/bacalhau.js
+++ b/lib/bacalhau.js
@@ -26,6 +26,41 @@ export async function install () {
   })
 }
 
+const getApiUrl = childProcess => new Promise((resolve, reject) => {
+  let output = ''
+
+  const readyHandler = data => {
+    output += data.toString()
+
+    const apiMatch = output.match(/^API: (http.*)$/m)
+    if (apiMatch) {
+      childProcess.stdout.off('data', readyHandler)
+      const apiUrl = apiMatch[1]
+      resolve(apiUrl)
+    }
+  }
+  childProcess.stdout.on('data', readyHandler)
+  childProcess.catch(reject)
+})
+
+const runMetricsLoop = async ({ childProcess, apiUrl, onMetrics }) => {
+  while (true) {
+    if (
+      childProcess.exitCode !== null ||
+      childProcess.signalCode !== null
+    ) {
+      break
+    }
+    try {
+      await updateStats({ apiUrl, onMetrics })
+    } catch (err) {
+      const errString = err.stack || err.message || err
+      console.error(`Cannot fetch Bacalhau module stats. ${errString}`)
+    }
+    await timers.setTimeout(1000)
+  }
+}
+
 export async function run ({
   FIL_WALLET_ADDRESS,
   storagePath,
@@ -68,23 +103,6 @@ export async function run ({
   })
   childProcess.stderr.pipe(process.stderr, { end: false })
 
-  const readyPromise = new Promise((resolve, reject) => {
-    let output = ''
-
-    const readyHandler = data => {
-      output += data.toString()
-
-      const apiMatch = output.match(/^API: (http.*)$/m)
-      if (apiMatch) {
-        childProcess.stdout.off('data', readyHandler)
-        const apiUrl = apiMatch[1]
-        resolve(apiUrl)
-      }
-    }
-    childProcess.stdout.on('data', readyHandler)
-    childProcess.catch(reject)
-  })
-
   childProcess.on('exit', (code, signal) => {
     const reason = signal ? `via signal ${signal}` : `with code: ${code}`
     const msg = `Bacalhau exited ${reason}`
@@ -95,7 +113,7 @@ export async function run ({
     (async () => {
       let apiUrl
       try {
-        apiUrl = await readyPromise
+        apiUrl = await getApiUrl(childProcess)
       } catch (err) {
         const errorMsg = err instanceof Error ? err.message : '' + err
         const message = `Cannot start Bacalhau: ${errorMsg}`
@@ -104,21 +122,7 @@ export async function run ({
       }
 
       onActivity({ type: 'info', message: 'Bacalhau module started.' })
-      while (true) {
-        if (
-          childProcess.exitCode !== null ||
-          childProcess.signalCode !== null
-        ) {
-          break
-        }
-        try {
-          await updateStats({ apiUrl, onMetrics })
-        } catch (err) {
-          const errString = err.stack || err.message || err
-          console.error(`Cannot fetch Bacalhau module stats. ${errString}`)
-        }
-        await timers.setTimeout(1000)
-      }
+      await runMetricsLoop({ childProcess, apiUrl, onMetrics })
     })(),
     (async () => {
       const [code] = await once(childProcess, 'close')

--- a/lib/bacalhau.js
+++ b/lib/bacalhau.js
@@ -57,17 +57,17 @@ export async function start ({
     }
   )
 
-  const readyPromise = new Promise((resolve, reject) => {
-    childProcess.stdout.setEncoding('utf-8')
-    childProcess.stdout.on('data', data => {
-      if (data.includes('/compute/debug') && data.includes(200)) {
-        // Ignore noisy lines
-        return
-      }
-      handleActivityLogs({ onActivity, text: data })
-    })
-    childProcess.stderr.pipe(process.stderr, { end: false })
+  childProcess.stdout.setEncoding('utf-8')
+  childProcess.stdout.on('data', data => {
+    if (data.includes('/compute/debug') && data.includes(200)) {
+      // Ignore noisy lines
+      return
+    }
+    handleActivityLogs({ onActivity, text: data })
+  })
+  childProcess.stderr.pipe(process.stderr, { end: false })
 
+  const readyPromise = new Promise((resolve, reject) => {
     let output = ''
 
     const readyHandler = data => {

--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -1,4 +1,3 @@
-import timers from 'node:timers/promises'
 import execa from 'execa'
 import Sentry from '@sentry/node'
 import { installBinaryModule, downloadSourceFiles, getBinaryModuleExecutable } from './modules.js'
@@ -58,20 +57,11 @@ export async function run ({
     }
   })
 
-  const readyPromise = new Promise((resolve, reject) => {
-    childProcess.stdout.setEncoding('utf-8')
-    childProcess.stdout.on('data', data => {
-      handleEvents({ onActivity, onMetrics, text: data })
-    })
-    childProcess.stderr.pipe(process.stderr, { end: false })
-
-    childProcess.stdout.once('data', _data => {
-      // This is based on an implicit assumption that zinniad reports an info activity
-      // after it starts
-      resolve()
-    })
-    childProcess.catch(reject)
+  childProcess.stdout.setEncoding('utf-8')
+  childProcess.stdout.on('data', data => {
+    handleEvents({ onActivity, onMetrics, text: data })
   })
+  childProcess.stderr.pipe(process.stderr, { end: false })
 
   childProcess.on('exit', (code, signal) => {
     const reason = signal ? `via signal ${signal}` : `with code: ${code}`
@@ -82,15 +72,11 @@ export async function run ({
   await Promise.all([
     (async () => {
       try {
-        await Promise.race([
-          readyPromise,
-          timers.setTimeout(500)
-        ])
+        await childProcess
       } catch (err) {
         const errorMsg = err instanceof Error ? err.message : '' + err
         const message = `Cannot start Zinnia: ${errorMsg}`
         onActivity({ type: 'error', message })
-        childProcess.kill()
         throw err
       }
     })(),

--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -37,7 +37,7 @@ export async function install () {
   ])
 }
 
-export async function start ({
+export async function run ({
   FIL_WALLET_ADDRESS,
   STATE_ROOT,
   CACHE_ROOT,

--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -58,12 +58,6 @@ export async function run ({
     }
   })
 
-  childProcess.on('exit', (code, signal) => {
-    const reason = signal ? `via signal ${signal}` : `with code: ${code}`
-    const msg = `Zinnia exited ${reason}`
-    onActivity({ type: 'info', message: msg })
-  })
-
   const readyPromise = new Promise((resolve, reject) => {
     childProcess.stdout.setEncoding('utf-8')
     childProcess.stdout.on('data', data => {
@@ -77,6 +71,12 @@ export async function run ({
       resolve()
     })
     childProcess.catch(reject)
+  })
+
+  childProcess.on('exit', (code, signal) => {
+    const reason = signal ? `via signal ${signal}` : `with code: ${code}`
+    const msg = `Zinnia exited ${reason}`
+    onActivity({ type: 'info', message: msg })
   })
 
   await Promise.all([

--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -4,6 +4,7 @@ import Sentry from '@sentry/node'
 import { installBinaryModule, downloadSourceFiles, getBinaryModuleExecutable } from './modules.js'
 import { moduleBinaries } from './paths.js'
 import os from 'node:os'
+import { once } from 'node:events'
 
 const ZINNIA_DIST_TAG = 'v0.13.0'
 const ZINNIA_MODULES = [
@@ -57,6 +58,12 @@ export async function start ({
     }
   })
 
+  childProcess.on('exit', (code, signal) => {
+    const reason = signal ? `via signal ${signal}` : `with code: ${code}`
+    const msg = `Zinnia exited ${reason}`
+    onActivity({ type: 'info', message: msg })
+  })
+
   const readyPromise = new Promise((resolve, reject) => {
     childProcess.stdout.setEncoding('utf-8')
     childProcess.stdout.on('data', data => {
@@ -72,29 +79,29 @@ export async function start ({
     childProcess.catch(reject)
   })
 
-  childProcess.on('close', code => {
-    console.error(`Zinnia closed all stdio with code ${code ?? '<no code>'}`)
-    childProcess.stderr.removeAllListeners()
-    childProcess.stdout.removeAllListeners()
-    Sentry.captureException('Zinnia exited')
-  })
-
-  childProcess.on('exit', (code, signal) => {
-    const reason = signal ? `via signal ${signal}` : `with code: ${code}`
-    const msg = `Zinnia exited ${reason}`
-    onActivity({ type: 'info', message: msg })
-  })
-
-  try {
-    await Promise.race([
-      readyPromise,
-      timers.setTimeout(500)
-    ])
-  } catch (err) {
-    const errorMsg = err instanceof Error ? err.message : '' + err
-    const message = `Cannot start Zinnia: ${errorMsg}`
-    onActivity({ type: 'error', message })
-  }
+  await Promise.all([
+    (async () => {
+      try {
+        await Promise.race([
+          readyPromise,
+          timers.setTimeout(500)
+        ])
+      } catch (err) {
+        const errorMsg = err instanceof Error ? err.message : '' + err
+        const message = `Cannot start Zinnia: ${errorMsg}`
+        onActivity({ type: 'error', message })
+        throw err
+      }
+    })(),
+    (async () => {
+      const [code] = await once(childProcess, 'close')
+      console.error(`Zinnia closed all stdio with code ${code ?? '<no code>'}`)
+      childProcess.stderr.removeAllListeners()
+      childProcess.stdout.removeAllListeners()
+      Sentry.captureException('Zinnia exited')
+      throw new Error('Zinnia exited')
+    })()
+  ])
 }
 
 function handleEvents ({ onActivity, onMetrics, text }) {

--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -90,6 +90,7 @@ export async function start ({
         const errorMsg = err instanceof Error ? err.message : '' + err
         const message = `Cannot start Zinnia: ${errorMsg}`
         onActivity({ type: 'error', message })
+        childProcess.kill()
         throw err
       }
     })(),

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,6 +14,7 @@
         "@sentry/node": "^7.41.0",
         "execa": "^5.1.1",
         "gunzip-maybe": "^1.4.2",
+        "p-retry": "^5.1.2",
         "tar-fs": "^3.0.3",
         "undici": "^5.20.0",
         "unzip-stream": "^0.3.1",
@@ -513,6 +514,11 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/retry": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
+      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
     },
     "node_modules/@types/yargs": {
       "version": "17.0.24",
@@ -6375,6 +6381,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-retry": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.2.tgz",
+      "integrity": "sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==",
+      "dependencies": {
+        "@types/retry": "0.12.1",
+        "retry": "^0.13.1"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/p-timeout": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.1.tgz",
@@ -7513,6 +7534,14 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==",
+      "engines": {
+        "node": ">= 4"
       }
     },
     "node_modules/reusify": {
@@ -9234,6 +9263,11 @@
       "requires": {
         "@types/node": "*"
       }
+    },
+    "@types/retry": {
+      "version": "0.12.1",
+      "resolved": "https://registry.npmjs.org/@types/retry/-/retry-0.12.1.tgz",
+      "integrity": "sha512-xoDlM2S4ortawSWORYqsdU+2rxdh4LRW9ytc3zmT37RIKQh6IHyKwwtKhKis9ah8ol07DCkZxPt8BBvPjC6v4g=="
     },
     "@types/yargs": {
       "version": "17.0.24",
@@ -13420,6 +13454,15 @@
         }
       }
     },
+    "p-retry": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/p-retry/-/p-retry-5.1.2.tgz",
+      "integrity": "sha512-couX95waDu98NfNZV+i/iLt+fdVxmI7CbrrdC2uDWfPdUAApyxT4wmDlyOtR5KtTDmkDO0zDScDjDou9YHhd9g==",
+      "requires": {
+        "@types/retry": "0.12.1",
+        "retry": "^0.13.1"
+      }
+    },
     "p-timeout": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-6.1.1.tgz",
@@ -14220,6 +14263,11 @@
         "onetime": "^5.1.0",
         "signal-exit": "^3.0.2"
       }
+    },
+    "retry": {
+      "version": "0.13.1",
+      "resolved": "https://registry.npmjs.org/retry/-/retry-0.13.1.tgz",
+      "integrity": "sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg=="
     },
     "reusify": {
       "version": "1.0.4",

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
     "@sentry/node": "^7.41.0",
     "execa": "^5.1.1",
     "gunzip-maybe": "^1.4.2",
+    "p-retry": "^5.1.2",
     "tar-fs": "^3.0.3",
     "undici": "^5.20.0",
     "unzip-stream": "^0.3.1",


### PR DESCRIPTION
Alternative implementation to https://github.com/filecoin-station/core/pull/169.

Notable differences:

Instead of the zinnia lib restarting itself internally, we make `zinnia.start()` throw an error when it exists. Then, we use `p-retry()` to take care of restarting it