### PR TITLE
Add back f1 support (deprecated). Closes #231

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -81,7 +81,7 @@ jobs:
          docker run \
            --name station \
            --detach \
-           --env FIL_WALLET_ADDRESS=f410fhgyuvi4k35wnqkvtdpewptt2oihbchvy5bdlmxy \
+           --env FIL_WALLET_ADDRESS=0x000000000000000000000000000000000000dEaD \
            $IMAGEID
         env:
           IMAGEID: ${{ steps.docker_build.outputs.imageid }}

--- a/README.md
+++ b/README.md
@@ -71,7 +71,10 @@ the configuration options described in
 
 - `FIL_WALLET_ADDRESS` _(string; required)_: Address of the Filecoin wallet that
   will receive rewards. The value must be a mainnet address starting with
-  `f410`, `0x` (or `f1`, deprecated).
+  `f410`, `0x`. 
+  
+  Addresses starting with `f1` are deprecated. We allow them
+  for now but will start rejecting them in an upcoming version.
 
   If you just want to give `core` a quick spin, you can use the address
   `0x000000000000000000000000000000000000dEaD`. Please note that any earnings

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ $ npm install -g @filecoin-station/core
 ## Usage
 
 ```bash
-$ FIL_WALLET_ADDRESS=f410/0x... station
+$ FIL_WALLET_ADDRESS=... station
 ```
 
 ## Common Configuration
@@ -70,12 +70,11 @@ the configuration options described in
 [Common Configuration](#common-configuration):
 
 - `FIL_WALLET_ADDRESS` _(string; required)_: Address of the Filecoin wallet that
-  will receive rewards. The value must be a mainnet address starting with `f410`
-  or `0x`.
+  will receive rewards. The value must be a mainnet address starting with
+  `f410`, `0x` (or `f1`, deprecated).
 
   If you just want to give `core` a quick spin, you can use the address
-  `f410fhgyuvi4k35wnqkvtdpewptt2oihbchvy5bdlmxy` or respectively
-  `0x39b14aa38adf6cd82aB31BC967Ce7a720E111Eb8`. Please note that any earnings
+  `0x000000000000000000000000000000000000dEaD`. Please note that any earnings
   sent there will be lost.
 
 This command outputs metrics and activity events:
@@ -150,7 +149,7 @@ Deploy Station with [Docker](https://www.docker.com/). Please replace
 $ docker run \
 	--name station \
 	--detach \
-	--env FIL_WALLET_ADDRESS=f410fhgyuvi4k35wnqkvtdpewptt2oihbchvy5bdlmxy \
+	--env FIL_WALLET_ADDRESS=0x000000000000000000000000000000000000dEaD \
 	ghcr.io/filecoin-station/core
 ```
 

--- a/README.md
+++ b/README.md
@@ -47,12 +47,12 @@ Station Core is configured using environment variables (see
 
 The following configuration options are shared by all Station commands:
 
-- `$CACHE_ROOT`_(string; optional)_: Station stores temporary files (e.g. cached
-  data) in this directory. Defaults to
+- `$CACHE_ROOT` _(string; optional)_: Station stores temporary files (e.g.
+  cached data) in this directory. Defaults to
   - Linux: `${XDG_CACHE_HOME:-~/.cache}/filecoin-station-core`
   - macOS: `~/Library/Caches/app.filstation.core`
   - Windows: `%TEMP%/Filecoin Station Core`
-- `$STATE_ROOT`_(string; optional)_: Station stores logs and module state in
+- `$STATE_ROOT` _(string; optional)_: Station stores logs and module state in
   this directory. Defaults to
   - Linux: `${XDG_STATE_HOME:-~/.local/state}/filecoin-station-core`
   - macOS: `~/Library/Application Support/app.filstation.core`
@@ -71,10 +71,10 @@ the configuration options described in
 
 - `FIL_WALLET_ADDRESS` _(string; required)_: Address of the Filecoin wallet that
   will receive rewards. The value must be a mainnet address starting with
-  `f410`, `0x`. 
-  
-  Addresses starting with `f1` are deprecated. We allow them
-  for now but will start rejecting them in an upcoming version.
+  `f410`, `0x`.
+
+  Addresses starting with `f1` are deprecated. We allow them for now but will
+  start rejecting them in an upcoming version.
 
   If you just want to give `core` a quick spin, you can use the address
   `0x000000000000000000000000000000000000dEaD`. Please note that any earnings

--- a/commands/station.js
+++ b/commands/station.js
@@ -20,7 +20,12 @@ export const station = async ({ json, experimental }) => {
     console.error('FIL_WALLET_ADDRESS required')
     process.exit(1)
   }
-  if (!FIL_WALLET_ADDRESS.startsWith('f410') && !FIL_WALLET_ADDRESS.startsWith('0x')) {
+  if (FIL_WALLET_ADDRESS.startsWith('f1')) {
+    console.error('Warning: f1... addresses are deprecated')
+  } else if (
+    !FIL_WALLET_ADDRESS.startsWith('f410') &&
+    !FIL_WALLET_ADDRESS.startsWith('0x')
+  ) {
     console.error('FIL_WALLET_ADDRESS must start with f410 or 0x')
     process.exit(1)
   }

--- a/commands/station.js
+++ b/commands/station.js
@@ -21,7 +21,8 @@ export const station = async ({ json, experimental }) => {
     process.exit(1)
   }
   if (FIL_WALLET_ADDRESS.startsWith('f1')) {
-    console.error('Warning: f1... addresses are deprecated')
+    console.error('Warning: f1... addresses are deprecated and will not receive any rewards.')
+    console.error('Please use an address starting with f410 or 0x')
   } else if (
     !FIL_WALLET_ADDRESS.startsWith('f410') &&
     !FIL_WALLET_ADDRESS.startsWith('0x')

--- a/test/util.js
+++ b/test/util.js
@@ -1,6 +1,6 @@
 import { fileURLToPath } from 'node:url'
 
-export const FIL_WALLET_ADDRESS = 'f410fhgyuvi4k35wnqkvtdpewptt2oihbchvy5bdlmxy'
+export const FIL_WALLET_ADDRESS = '0x000000000000000000000000000000000000dEaD'
 
 export const station = fileURLToPath(
   new URL('../bin/station.js', import.meta.url)


### PR DESCRIPTION
Closes #231

Temporary fix while Station Desktop doesn't yet support 0x/f4 addresses.