### PR TITLE
Fix retry wallet address check

### DIFF
--- a/commands/station.js
+++ b/commands/station.js
@@ -32,8 +32,13 @@ export const station = async ({ json, experimental }) => {
   ) {
     panic('FIL_WALLET_ADDRESS must start with f410 or 0x')
   }
-  const fetchRes = await fetch(
-    `https://station-wallet-screening.fly.dev/${FIL_WALLET_ADDRESS}`
+  const fetchRes = await pRetry(
+    () => fetch(`https://station-wallet-screening.fly.dev/${FIL_WALLET_ADDRESS}`),
+    {
+      retries: 1000,
+      onFailedAttempt: () =>
+        console.error('Failed to check FIL_WALLET_ADDRESS address. Retrying...')
+    }
   )
   if (fetchRes.status === 403) panic('Invalid FIL_WALLET_ADDRESS address')
   if (!fetchRes.ok) panic('Failed to check FIL_WALLET_ADDRESS address')

--- a/package-lock.json
+++ b/package-lock.json
@@ -14,7 +14,7 @@
         "@sentry/node": "^7.41.0",
         "execa": "^8.0.1",
         "gunzip-maybe": "^1.4.2",
-        "p-retry": "^6.0.0",
+        "p-retry": "^6.1.0",
         "tar-fs": "^3.0.3",
         "undici": "^5.20.0",
         "unzip-stream": "^0.3.1",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@sentry/node": "^7.41.0",
     "execa": "^8.0.1",
     "gunzip-maybe": "^1.4.2",
-    "p-retry": "^6.0.0",
+    "p-retry": "^6.1.0",
     "tar-fs": "^3.0.3",
     "undici": "^5.20.0",
     "unzip-stream": "^0.3.1",


### PR DESCRIPTION
@bajtos hindsight please

This fixes an error in Station Desktop, where you have it launch at boot, but your network isn't ready yet -> `core` fails to launch and `desktop` doesn't recover.

Alternatives considered:

- Remove address check from `core` when it's launched by `desktop`, which will only supply Station-created addresses. This would be the simplest solution. Need to double check with legal if we may add this option. Downside: If one of the Station wallets gets sanctioned, this doesn't catch it.
- Add retry logic to Station Desktop. I think this would be nicer overall, but a more difficult change. Wdyt?