### PR TITLE
Fix scheduled rewards display

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ This command outputs metrics and activity events:
 $ station
 {
   "totalJobsCompleted": 161,
-  "rewardsScheduledForAddress": "0"
+  "rewardsScheduledForAddress": "0.041033208757289921"
 }
 [4/19/2023, 9:26:54 PM] INFO  Saturn Node will try to connect to the Saturn Orchestrator...
 [4/19/2023, 9:26:54 PM] INFO  Saturn Node was able to connect to the Orchestrator and will now start connecting to the Saturn network...

--- a/commands/station.js
+++ b/commands/station.js
@@ -9,6 +9,7 @@ import { paths } from '../lib/paths.js'
 import pRetry from 'p-retry'
 import { fetch } from 'undici'
 import { ethAddressFromDelegated } from '@glif/filecoin-address'
+import { formatEther } from 'ethers'
 
 const { FIL_WALLET_ADDRESS } = process.env
 
@@ -72,7 +73,11 @@ export const station = async ({ json, experimental }) => {
         total: metrics.totalJobsCompleted
       }))
     } else {
-      console.log(JSON.stringify(metrics, null, 2))
+      console.log(JSON.stringify({
+        totalJobsCompleted: metrics.totalJobsCompleted,
+        rewardsScheduledForAddress:
+          formatEther(metrics.rewardsScheduledForAddress)
+      }, null, 2))
     }
   })
 

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -51,6 +51,8 @@ export class Metrics {
     }
     for (const [, metrics] of this.moduleMetrics) {
       mergedMetrics.totalJobsCompleted += metrics.totalJobsCompleted
+      mergedMetrics.rewardsScheduledForAddress +=
+        metrics.rewardsScheduledForAddress
     }
     const isChanged = this.mergedMetrics === null ||
       Object

--- a/lib/metrics.js
+++ b/lib/metrics.js
@@ -6,7 +6,7 @@ export class MetricsEvent {
   /**
    * @param {Object} options
    * @param {Number} options.totalJobsCompleted
-   * @param {String} options.rewardsScheduledForAddress
+   * @param {bigint} options.rewardsScheduledForAddress
    */
   constructor ({ totalJobsCompleted, rewardsScheduledForAddress }) {
     this.totalJobsCompleted = totalJobsCompleted
@@ -47,7 +47,7 @@ export class Metrics {
     this.moduleMetrics.set(moduleName, metrics)
     const mergedMetrics = {
       totalJobsCompleted: 0,
-      rewardsScheduledForAddress: '0'
+      rewardsScheduledForAddress: 0n
     }
     for (const [, metrics] of this.moduleMetrics) {
       mergedMetrics.totalJobsCompleted += metrics.totalJobsCompleted

--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -151,7 +151,7 @@ async function handleEvents ({
           onMetrics({
             totalJobsCompleted: event.total,
             rewardsScheduledForAddress:
-              (await contract.rewardsScheduledFor(ethAddress)).toString()
+              await contract.rewardsScheduledFor(ethAddress)
           })
           break
 

--- a/test/metrics.js
+++ b/test/metrics.js
@@ -7,15 +7,15 @@ describe('Metrics', () => {
       const metrics = new Metrics()
       metrics.submit('module1', {
         totalJobsCompleted: 1,
-        rewardsScheduledForAddress: '0'
+        rewardsScheduledForAddress: 1n
       })
       metrics.submit('module2', {
         totalJobsCompleted: 2,
-        rewardsScheduledForAddress: '0'
+        rewardsScheduledForAddress: 2n
       })
       assert.deepStrictEqual(metrics.mergedMetrics, {
         totalJobsCompleted: 3,
-        rewardsScheduledForAddress: '0'
+        rewardsScheduledForAddress: 3n
       })
     })
     it('should filter duplicate entries', () => {
@@ -25,12 +25,12 @@ describe('Metrics', () => {
         if (i === 0) {
           assert.deepStrictEqual(metrics, {
             totalJobsCompleted: 1,
-            rewardsScheduledForAddress: '0'
+            rewardsScheduledForAddress: 0n
           })
         } else if (i === 1) {
           assert.deepStrictEqual(metrics, {
             totalJobsCompleted: 2,
-            rewardsScheduledForAddress: '0'
+            rewardsScheduledForAddress: 0n
           })
         } else {
           throw new Error('should not be called')
@@ -39,15 +39,15 @@ describe('Metrics', () => {
       })
       metrics.submit('module1', {
         totalJobsCompleted: 1,
-        rewardsScheduledForAddress: '0'
+        rewardsScheduledForAddress: 0n
       })
       metrics.submit('module1', {
         totalJobsCompleted: 1,
-        rewardsScheduledForAddress: '0'
+        rewardsScheduledForAddress: 0n
       })
       metrics.submit('module2', {
         totalJobsCompleted: 1,
-        rewardsScheduledForAddress: '0'
+        rewardsScheduledForAddress: 0n
       })
     })
   })


### PR DESCRIPTION
There was an issue in the metrics merging logic (shipped too fast :|), it was always showing 0. Fixed this:

```
{
  "totalJobsCompleted": 680,
  "rewardsScheduledForAddress": "0.041033208757289921"
}
```