### PR TITLE
fix: report Zinnia crashes to Sentry every 4 hours

### DIFF
--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -39,6 +39,16 @@ export async function install () {
   ])
 }
 
+let lastCrashReportedAt = 0
+const maybeReportCrashToSentry = (/** @type {unknown} */ err) => {
+  const now = Date.now()
+  if (now - lastCrashReportedAt < 4 /* HOURS */ * 3600_000) return
+  lastCrashReportedAt = Date.now()
+
+  console.log('Reporting the problem to Sentry for inspection by the Station team.')
+  Sentry.captureException(err)
+}
+
 export async function run ({
   FIL_WALLET_ADDRESS,
   ethAddress,
@@ -92,9 +102,10 @@ export async function run ({
   })
   childProcess.stderr.pipe(process.stderr, { end: false })
 
+  let exitReason
   childProcess.on('exit', (code, signal) => {
-    const reason = signal ? `via signal ${signal}` : `with code: ${code}`
-    const msg = `Zinnia exited ${reason}`
+    exitReason = signal ? `via signal ${signal}` : `with code: ${code}`
+    const msg = `Zinnia exited ${exitReason}`
     onActivity({ type: 'info', message: msg })
   })
 
@@ -106,6 +117,7 @@ export async function run ({
         const errorMsg = err instanceof Error ? err.message : '' + err
         const message = `Cannot start Zinnia: ${errorMsg}`
         onActivity({ type: 'error', message })
+        maybeReportCrashToSentry(err)
         throw err
       }
     })(),
@@ -114,8 +126,9 @@ export async function run ({
       console.error(`Zinnia closed all stdio with code ${code ?? '<no code>'}`)
       childProcess.stderr.removeAllListeners()
       childProcess.stdout.removeAllListeners()
-      Sentry.captureException('Zinnia exited')
-      throw new Error('Zinnia exited')
+      const err = new Error(`Zinnia exited ${exitReason ?? 'for unknown reason'}`)
+      maybeReportCrashToSentry(err)
+      throw err
     })()
   ])
 }


### PR DESCRIPTION
Prevent the network from depleting our allowance for incoming error reports in Sentry.

Related:
- https://github.com/filecoin-station/core/pull/170
- https://github.com/filecoin-station/zinnia/issues/146
