### PR TITLE
feat: upgrade Dockerfile to Node.js 20 LTS

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:18
+FROM node:20
 LABEL org.opencontainers.image.source https://github.com/filecoin-station/core
 USER node
 WORKDIR /usr/src/app


### PR DESCRIPTION
Interestingly enough, this seems to fix the network errors we observed before 🤷🏻‍♂️ 

Example of such errors:

```
npm ERR! code ECONNRESET
npm ERR! errno ECONNRESET
npm ERR! network request to https://registry.npmjs.org/is-network-error/-/is-network-error-1.0.0.tgz failed, reason: socket hang up
npm ERR! network This is a problem related to network connectivity.
npm ERR! network In most cases you are behind a proxy or have bad network settings.
```