### PR TITLE
feat: upgrade Zinnia to v0.16.0

### DIFF
--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -8,7 +8,7 @@ import { ethers } from 'ethers'
 import fs from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 
-const ZINNIA_DIST_TAG = 'v0.15.0'
+const ZINNIA_DIST_TAG = 'v0.16.0'
 const ZINNIA_MODULES = [
   {
     module: 'spark',


### PR DESCRIPTION
https://github.com/filecoin-station/zinnia/releases/tag/v0.16.0

**Highlights ✨**

Upgrade Rusty Lassie to v0.8.0. We now configure Lassie's user agent to report the Go Lassie version plus our custom suffix, e.g. `lassie/v0.21.0-rs`.
