### PR TITLE
zinnia: set max update retries to 10

### DIFF
--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -52,7 +52,7 @@ const updateAllSourceFiles = async () => {
         pRetry(
           () => updateSourceFiles({ module, repo }),
           {
-            retries: 1000,
+            retries: 10,
             onFailedAttempt: err => {
               console.error(err)
               console.error(`Failed to download ${module} source. Retrying...`)


### PR DESCRIPTION
Due to exponential backoff logic, 10 retries already take >1 minute to complete