### PR TITLE
Fix redundant module updates

### DIFF
--- a/commands/station.js
+++ b/commands/station.js
@@ -88,7 +88,7 @@ export const station = async ({ json, experimental }) => {
       ethAddress,
       STATE_ROOT: join(paths.moduleState, 'zinnia'),
       CACHE_ROOT: join(paths.moduleCache, 'zinnia'),
-      latestModuleVersions: paths.latestModuleVersions,
+      moduleVersionsDir: paths.moduleVersionsDir,
       onActivity: activity => {
         activities.submit({
           ...activity,

--- a/commands/station.js
+++ b/commands/station.js
@@ -88,6 +88,7 @@ export const station = async ({ json, experimental }) => {
       ethAddress,
       STATE_ROOT: join(paths.moduleState, 'zinnia'),
       CACHE_ROOT: join(paths.moduleCache, 'zinnia'),
+      latestModuleVersions: paths.latestModuleVersions,
       onActivity: activity => {
         activities.submit({
           ...activity,

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -115,9 +115,9 @@ async function getLatestDistTag (repo) {
   return body.tag_name
 }
 
-async function getLastSeenModuleDistTag ({ module, latestModuleVersions }) {
+async function getLastSeenModuleDistTag ({ module, moduleVersionsDir }) {
   try {
-    return await readFile(join(latestModuleVersions, module), 'utf-8')
+    return await readFile(join(moduleVersionsDir, module), 'utf-8')
   } catch (err) {
     if (err.code !== 'ENOENT') {
       throw err
@@ -126,16 +126,16 @@ async function getLastSeenModuleDistTag ({ module, latestModuleVersions }) {
   return undefined
 }
 
-async function setLastSeenModuleDistTag ({ module, distTag, latestModuleVersions }) {
-  await mkdir(latestModuleVersions)
-  await writeFile(join(latestModuleVersions, module), distTag)
+async function setLastSeenModuleDistTag ({ module, distTag, moduleVersionsDir }) {
+  await mkdir(moduleVersionsDir)
+  await writeFile(join(moduleVersionsDir, module), distTag)
 }
 
-export async function updateSourceFiles ({ module, repo, latestModuleVersions }) {
+export async function updateSourceFiles ({ module, repo, moduleVersionsDir }) {
   await mkdir(moduleBinaries, { recursive: true })
   const outDir = join(moduleBinaries, module)
 
-  const lastSeenDistTag = await getLastSeenModuleDistTag({ module, latestModuleVersions })
+  const lastSeenDistTag = await getLastSeenModuleDistTag({ module, moduleVersionsDir })
   if (lastSeenDistTag !== undefined) {
     // Use `console.error` because with `--json` stdout needs to be JSON only
     console.error(`[${module}]  ⇣ checking for updates`)
@@ -178,7 +178,7 @@ export async function updateSourceFiles ({ module, repo, latestModuleVersions })
     throw err
   }
 
-  await setLastSeenModuleDistTag({ module, distTag, latestModuleVersions })
+  await setLastSeenModuleDistTag({ module, distTag, moduleVersionsDir })
   console.error(`[${module}]  ✓ ${outDir}`)
 
   return isUpdate

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -1,7 +1,7 @@
 import os from 'node:os'
 import assert from 'node:assert'
 import { join } from 'node:path'
-import { mkdir, chmod, rmdir } from 'node:fs/promises'
+import { mkdir, chmod, rmdir, readFile, writeFile } from 'node:fs/promises'
 import { fetch } from 'undici'
 import { pipeline } from 'node:stream/promises'
 import gunzip from 'gunzip-maybe'
@@ -115,19 +115,34 @@ async function getLatestDistTag (repo) {
   return body.tag_name
 }
 
-const lastModuleDistTag = new Map()
+async function getLastSeenModuleDistTag ({ module, latestModuleVersions }) {
+  try {
+    return await readFile(join(latestModuleVersions, module), 'utf-8')
+  } catch (err) {
+    if (err.code !== 'ENOENT') {
+      throw err
+    }
+  }
+  return undefined
+}
 
-export async function updateSourceFiles ({ module, repo }) {
+async function setLastSeenModuleDistTag ({ module, distTag, latestModuleVersions }) {
+  await mkdir(latestModuleVersions)
+  await writeFile(join(latestModuleVersions, module), distTag)
+}
+
+export async function updateSourceFiles ({ module, repo, latestModuleVersions }) {
   await mkdir(moduleBinaries, { recursive: true })
   const outDir = join(moduleBinaries, module)
 
-  if (lastModuleDistTag.has(module)) {
+  const lastSeenDistTag = await getLastSeenModuleDistTag({ module, latestModuleVersions })
+  if (lastSeenDistTag !== undefined) {
     // Use `console.error` because with `--json` stdout needs to be JSON only
     console.error(`[${module}]  ⇣ checking for updates`)
   }
 
   const distTag = await getLatestDistTag(repo)
-  const isUpdate = lastModuleDistTag.get(module) !== distTag
+  const isUpdate = lastSeenDistTag !== distTag
   if (!isUpdate) {
     console.error(`[${module}]  ✓ no update available`)
     return isUpdate
@@ -163,7 +178,7 @@ export async function updateSourceFiles ({ module, repo }) {
     throw err
   }
 
-  lastModuleDistTag.set(module, distTag)
+  await setLastSeenModuleDistTag({ module, distTag, latestModuleVersions })
   console.error(`[${module}]  ✓ ${outDir}`)
 
   return isUpdate

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -15,7 +15,7 @@ const {
 export const getPaths = ({ cacheRoot, stateRoot }) => ({
   moduleCache: join(cacheRoot, 'modules'),
   moduleState: join(stateRoot, 'modules'),
-  latestModuleVersions: join(stateRoot, 'modules', 'latest'),
+  moduleVersionsDir: join(stateRoot, 'modules', 'latest'),
   lockFile: join(stateRoot, '.lock')
 })
 

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -15,6 +15,7 @@ const {
 export const getPaths = ({ cacheRoot, stateRoot }) => ({
   moduleCache: join(cacheRoot, 'modules'),
   moduleState: join(stateRoot, 'modules'),
+  latestModuleVersions: join(stateRoot, 'modules', 'latest'),
   lockFile: join(stateRoot, '.lock')
 })
 

--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -44,13 +44,13 @@ const maybeReportCrashToSentry = (/** @type {unknown} */ err) => {
   Sentry.captureException(err)
 }
 
-const updateAllSourceFiles = async (latestModuleVersions) => {
+const updateAllSourceFiles = async (moduleVersionsDir) => {
   const modules = await Promise.all(
     Object
       .values(ZINNIA_MODULES)
       .map(({ module, repo }) =>
         pRetry(
-          () => updateSourceFiles({ module, repo, latestModuleVersions }),
+          () => updateSourceFiles({ module, repo, moduleVersionsDir }),
           {
             retries: 10,
             onFailedAttempt: err => {
@@ -70,7 +70,7 @@ export async function run ({
   ethAddress,
   STATE_ROOT,
   CACHE_ROOT,
-  latestModuleVersions,
+  moduleVersionsDir,
   onActivity,
   onMetrics,
   isUpdated = false
@@ -108,7 +108,7 @@ export async function run ({
         type: 'info',
         message: 'Updating source code for Zinnia modules...'
       })
-      await updateAllSourceFiles(latestModuleVersions)
+      await updateAllSourceFiles(moduleVersionsDir)
       onActivity({
         type: 'info',
         message: 'Zinnia module source code up to date'
@@ -160,7 +160,7 @@ export async function run ({
       while (true) {
         await timers.setTimeout(10 * 60 * 1000) // 10 minutes
         try {
-          shouldRestart = await updateAllSourceFiles(latestModuleVersions)
+          shouldRestart = await updateAllSourceFiles(moduleVersionsDir)
         } catch (err) {
           onActivity({
             type: 'error',
@@ -209,7 +209,7 @@ export async function run ({
       ethAddress,
       STATE_ROOT,
       CACHE_ROOT,
-      latestModuleVersions,
+      moduleVersionsDir,
       onActivity,
       onMetrics,
       isUpdated: true

--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -44,13 +44,13 @@ const maybeReportCrashToSentry = (/** @type {unknown} */ err) => {
   Sentry.captureException(err)
 }
 
-const updateAllSourceFiles = async () => {
+const updateAllSourceFiles = async (latestModuleVersions) => {
   const modules = await Promise.all(
     Object
       .values(ZINNIA_MODULES)
       .map(({ module, repo }) =>
         pRetry(
-          () => updateSourceFiles({ module, repo }),
+          () => updateSourceFiles({ module, repo, latestModuleVersions }),
           {
             retries: 10,
             onFailedAttempt: err => {
@@ -70,6 +70,7 @@ export async function run ({
   ethAddress,
   STATE_ROOT,
   CACHE_ROOT,
+  latestModuleVersions,
   onActivity,
   onMetrics,
   isUpdated = false
@@ -208,6 +209,7 @@ export async function run ({
       ethAddress,
       STATE_ROOT,
       CACHE_ROOT,
+      latestModuleVersions,
       onActivity,
       onMetrics,
       isUpdated: true

--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -106,17 +106,17 @@ export async function run ({
     try {
       onActivity({
         type: 'info',
-        message: 'Downloading latest source code for Zinnia modules...'
+        message: 'Updating source code for Zinnia modules...'
       })
-      await updateAllSourceFiles()
+      await updateAllSourceFiles(latestModuleVersions)
       onActivity({
         type: 'info',
-        message: 'Zinnia Module source code download completed'
+        message: 'Zinnia module source code up to date'
       })
     } catch (err) {
       onActivity({
         type: 'error',
-        message: 'Failed to download latest Zinnia module source files'
+        message: 'Failed to download latest Zinnia module source code'
       })
       throw err
     }
@@ -160,17 +160,17 @@ export async function run ({
       while (true) {
         await timers.setTimeout(10 * 60 * 1000) // 10 minutes
         try {
-          shouldRestart = await updateAllSourceFiles()
+          shouldRestart = await updateAllSourceFiles(latestModuleVersions)
         } catch (err) {
           onActivity({
             type: 'error',
-            message: 'Failed to update Zinnia module source files'
+            message: 'Failed to update Zinnia module source code'
           })
         }
         if (shouldRestart) {
           onActivity({
             type: 'info',
-            message: 'Updated Zinnia module source files, restarting...'
+            message: 'Updated Zinnia module source code, restarting...'
           })
           childProcess.kill()
           return


### PR DESCRIPTION
By storing the latest installed module version in a text file, prevent redundant updates.