### PR TITLE
fix store module sources in CACHE_ROOT

### DIFF
--- a/commands/station.js
+++ b/commands/station.js
@@ -87,6 +87,7 @@ export const station = async ({ json, experimental }) => {
       STATE_ROOT: join(paths.moduleState, 'zinnia'),
       CACHE_ROOT: join(paths.moduleCache, 'zinnia'),
       moduleVersionsDir: paths.moduleVersionsDir,
+      moduleSourcesDir: paths.moduleSourcesDir,
       onActivity: activity => {
         activities.submit({
           ...activity,

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -1,7 +1,7 @@
 import os from 'node:os'
 import assert from 'node:assert'
 import { join } from 'node:path'
-import { mkdir, chmod, rm, readFile, writeFile } from 'node:fs/promises'
+import { mkdir, chmod, rm, readFile, writeFile, stat } from 'node:fs/promises'
 import { fetch } from 'undici'
 import { pipeline } from 'node:stream/promises'
 import gunzip from 'gunzip-maybe'
@@ -118,9 +118,14 @@ async function setLastSeenModuleCID ({ module, cid, moduleVersionsDir }) {
   await writeFile(join(moduleVersionsDir, module), cid)
 }
 
-export async function updateSourceFiles ({ module, ipnsKey, moduleVersionsDir }) {
-  await mkdir(moduleBinaries, { recursive: true })
-  const outDir = join(moduleBinaries, module)
+export async function updateSourceFiles ({
+  module,
+  ipnsKey,
+  moduleVersionsDir,
+  moduleSourcesDir
+}) {
+  await mkdir(moduleSourcesDir, { recursive: true })
+  const outDir = join(moduleSourcesDir, module)
 
   const lastSeenCID = await getLastSeenModuleCID({ module, moduleVersionsDir })
   if (lastSeenCID !== undefined) {
@@ -131,8 +136,13 @@ export async function updateSourceFiles ({ module, ipnsKey, moduleVersionsDir })
   const cid = await getLatestCID(ipnsKey)
   const isUpdate = lastSeenCID !== cid
   if (!isUpdate) {
-    console.error(`[${module}]  ✓ no update available`)
-    return isUpdate
+    try {
+      await stat(outDir)
+      console.error(`[${module}]  ✓ no update available`)
+      return false
+    } catch (err) {
+      console.error(`[${module}] Cannot find sources on disk`)
+    }
   }
 
   const url = `https://${cid}.ipfs.w3s.link?format=car`

--- a/lib/paths.js
+++ b/lib/paths.js
@@ -15,6 +15,7 @@ const {
 export const getPaths = ({ cacheRoot, stateRoot }) => ({
   moduleCache: join(cacheRoot, 'modules'),
   moduleState: join(stateRoot, 'modules'),
+  moduleSourcesDir: join(cacheRoot, 'sources'),
   moduleVersionsDir: join(stateRoot, 'modules', 'latest'),
   lockFile: join(stateRoot, '.lock')
 })

--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -9,6 +9,7 @@ import fs from 'node:fs/promises'
 import { fileURLToPath } from 'node:url'
 import pRetry from 'p-retry'
 import timers from 'node:timers/promises'
+import { join } from 'node:path'
 
 const ZINNIA_DIST_TAG = 'v0.16.0'
 const ZINNIA_MODULES = [
@@ -55,14 +56,22 @@ const matchesModuleFilter = module =>
 
 const capitalize = str => `${str.charAt(0).toUpperCase()}${str.slice(1)}`
 
-const updateAllSourceFiles = async (moduleVersionsDir) => {
+const updateAllSourceFiles = async ({
+  moduleVersionsDir,
+  moduleSourcesDir
+}) => {
   const modules = await Promise.all(
     Object
       .values(ZINNIA_MODULES)
       .filter(({ module }) => matchesModuleFilter(module))
       .map(({ module, ipnsKey }) =>
         pRetry(
-          () => updateSourceFiles({ module, ipnsKey, moduleVersionsDir }),
+          () => updateSourceFiles({
+            module,
+            ipnsKey,
+            moduleVersionsDir,
+            moduleSourcesDir
+          }),
           {
             retries: 10,
             onFailedAttempt: err => {
@@ -83,6 +92,7 @@ export async function run ({
   STATE_ROOT,
   CACHE_ROOT,
   moduleVersionsDir,
+  moduleSourcesDir,
   onActivity,
   onMetrics,
   isUpdated = false
@@ -118,7 +128,7 @@ export async function run ({
         type: 'info',
         message: 'Updating source code for Zinnia modules...'
       })
-      await updateAllSourceFiles(moduleVersionsDir)
+      await updateAllSourceFiles({ moduleVersionsDir, moduleSourcesDir })
       onActivity({
         type: 'info',
         message: 'Zinnia module source code up to date'
@@ -138,14 +148,18 @@ export async function run ({
     if (!matchesModuleFilter(module)) continue
 
     // all paths are relative to `moduleBinaries`
-    const childProcess = execa(zinniadExe, [`${module}/main.js`], {
-      cwd: moduleBinaries,
-      env: {
-        FIL_WALLET_ADDRESS,
-        STATE_ROOT,
-        CACHE_ROOT
+    const childProcess = execa(
+      zinniadExe,
+      [join(moduleSourcesDir, module, 'main.js')],
+      {
+        cwd: moduleBinaries,
+        env: {
+          FIL_WALLET_ADDRESS,
+          STATE_ROOT,
+          CACHE_ROOT
+        }
       }
-    })
+    )
     childProcesses.push(childProcess)
 
     childProcess.stdout.setEncoding('utf-8')
@@ -236,6 +250,7 @@ export async function run ({
       STATE_ROOT,
       CACHE_ROOT,
       moduleVersionsDir,
+      moduleSourcesDir,
       onActivity,
       onMetrics,
       isUpdated: true


### PR DESCRIPTION
The main directory isn't always writeable, eg when mounted inside an electron app. Therefore, store files inside CACHE_ROOT