### PR TITLE
update to node 18

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        node: ['16', '18', '19', '20']
+        node: ['18', '19', '20', '21']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -170,9 +170,9 @@ export async function updateSourceFiles ({
         try {
           await validateBlock(block)
         } catch (err) {
-          throw new Error(
-            `Invalid block ${blockCid} of root ${cid}. ${err.stack}`
-          )
+          throw new Error(`Invalid block ${blockCid} of root ${cid}`, {
+            cause: err
+          })
         }
         return block.bytes
       }

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "station": "./bin/station.js"
   },
   "engines": {
-    "node": ">=16"
+    "node": ">=18"
   },
   "scripts": {
     "build": "tsc -p .",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,8 +3,8 @@
     "allowJs": true,
     "checkJs": true,
     "skipLibCheck": true,
-    "lib": ["es2021"],
-    "target": "es2021",
+    "lib": ["es2022"],
+    "target": "es2022",
     "module": "Node16",
     "moduleResolution": "node16",
 


### PR DESCRIPTION
- Drop node 16 support ([past EOL](https://github.com/nodejs/Release))
- Update tsconfig to support the `{ cause }` parameter on `Error()`
- Don't update the tsconfig module settings, as otherwise this happens:

<img width="1344" alt="Screenshot 2024-02-05 at 13 01 25" src="https://github.com/filecoin-station/core/assets/10247/c167eb89-af4d-490f-83a8-3093fbc12b93">
