### PR TITLE
zinnia: fix module paths for logging

### DIFF
--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -1,7 +1,6 @@
 import { execa } from 'execa'
 import Sentry from '@sentry/node'
 import { installBinaryModule, updateSourceFiles, getBinaryModuleExecutable } from './modules.js'
-import { moduleBinaries } from './paths.js'
 import os from 'node:os'
 import { once } from 'node:events'
 import { ethers } from 'ethers'

--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -159,9 +159,9 @@ export async function run ({
     // all paths are relative to `moduleBinaries`
     const childProcess = execa(
       zinniadExe,
-      [join(moduleSourcesDir, module, 'main.js')],
+      [join(module, 'main.js')],
       {
-        cwd: moduleBinaries,
+        cwd: moduleSourcesDir,
         env: {
           FIL_WALLET_ADDRESS,
           STATE_ROOT,


### PR DESCRIPTION
Before:

```
[2024-02-08T09:38:58Z INFO  module:/Users/julian/Library/Caches/app.filstation.core/sources/spark/main] Getting current SPARK round details...
```

After:

```
[2024-02-08T09:42:37Z INFO  module:spark/main] Getting current SPARK round details...
```

This regression was introduced in https://github.com/filecoin-station/core/commit/f9ec3fd6a44089da62ee4c2a52a8e72350920621.