### PR TITLE
zinnia: fix verbose error activity

### DIFF
--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -229,9 +229,7 @@ export async function run ({
         await Promise.race(childProcesses)
       } catch (err) {
         if (!shouldRestart) {
-          const errorMsg = err instanceof Error ? err.message : '' + err
-          const message = `Cannot start Zinnia: ${errorMsg}`
-          onActivity({ type: 'error', message })
+          onActivity({ type: 'error', message: 'Zinnia crashed' })
           maybeReportErrorToSentry(err)
           throw err
         }


### PR DESCRIPTION
We don't want to show actual error stacks in Station Desktop