### PR TITLE
fix don't ddos w3name

### DIFF
--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -77,9 +77,12 @@ const updateAllSourceFiles = async ({
               console.error(err)
               console.error(`Failed to download ${module} source. Retrying...`)
               if (String(err).includes('You are being rate limited')) {
+                const delaySeconds = 30 + (Math.random() * 60)
                 // Don't DDOS the w3name services
-                console.error('Rate limited. Waiting 60 seconds...')
-                return timers.setTimeout(60_000)
+                console.error(
+                  `Rate limited. Waiting ${delaySeconds} seconds...`
+                )
+                return timers.setTimeout(delaySeconds * 1000)
               }
             }
           }

--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -76,6 +76,11 @@ const updateAllSourceFiles = async ({
             onFailedAttempt: err => {
               console.error(err)
               console.error(`Failed to download ${module} source. Retrying...`)
+              if (String(err).includes('You are being rate limited')) {
+                // Don't DDOS the w3name services
+                console.error('Rate limited. Waiting 60 seconds...')
+                return timers.setTimeout(60_000)
+              }
             }
           }
         )


### PR DESCRIPTION
Saw this in Sentry:

```
Error: You are being rate limited
    at S (file:///usr/src/app/node_modules/w3name/dist/index.mjs:1:2621)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
    at async Module.q (file:///usr/src/app/node_modules/w3name/dist/index.mjs:1:2298)
    at async getLatestCID (file:///usr/src/app/lib/modules.js:106:20)
    at async updateSourceFiles (file:///usr/src/app/lib/modules.js:142:15)
    at async RetryOperation._fn (file:///usr/src/app/node_modules/p-retry/index.js:57:20) {
  attemptNumber: 11,
  retriesLeft: 0
}
```

https://protocol-labs-ip.sentry.io/issues/4952775000/?project=4504792315199488&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=24h&stream_index=2

And w3name says:

> There is a rate limit of 30 requests per 10 seconds per IP.

Since this failed on the first attempt, it means that someone is running multiple stations on the same IP. Add 60s wait time before trying again, in order to put less load on w3name.