### PR TITLE
Fix occasional `ENOENT` during `tar.extract()`. Closes #1399

### DIFF
--- a/lib/modules.js
+++ b/lib/modules.js
@@ -203,6 +203,8 @@ export async function updateSourceFiles ({
     // Depending on size, entries might be packaged as `file` or `raw`
     // https://github.com/web3-storage/w3up/blob/e8bffe2ee0d3a59a977d2c4b7efe425699424e19/packages/upload-client/src/unixfs.js#L11
     if (entry.type === 'file' || entry.type === 'raw') {
+      // Fix occasional `ENOENT ${outDir}` during `tar.extract()`
+      await mkdir(outDir, { recursive: true })
       // `{ strip: 1}` tells tar to remove the top-level directory (e.g. `mod-peer-checker-v1.0.0`)
       await pipeline(
         entry.content(),


### PR DESCRIPTION
(Hopefully) closes #1399