### PR TITLE
zinnia: fix end update loops outside of signal event

### DIFF
--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -164,6 +164,9 @@ const runUpdateSourceFilesLoop = async ({
       }
       return
     }
+    if (signal.aborted) {
+      return
+    }
   }
 }
 
@@ -180,6 +183,9 @@ const runUpdateContractsLoop = async ({ signal, provider, abi, contracts }) => {
     const newContracts = await getContractsWithRetry(provider, abi)
     contracts.splice(0)
     contracts.push(...newContracts)
+    if (signal.aborted) {
+      return
+    }
   }
 }
 


### PR DESCRIPTION
I noticed looking at the `core-fly` logs that multiple update loops were running in parallel. This fixes the case when the abort controller is triggered but the async function that's currently running doesn't listen for it