### PR TITLE
rework Zinnia errors reported to Sentry

### DIFF
--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -245,7 +245,7 @@ const waitForStdioClose = async ({ childProcesses, controller }) => {
   const results = await Promise.all(
     childProcesses.map(childProcess => once(childProcess, 'close'))
   )
-  const codes = results.map(([code, signal]) => code || signal || '<no code>')
+  const codes = results.map(([code, signal]) => code || `<${signal}>` || '<no code>')
   console.error(`Zinnia closed all stdio with codes ${codes.join(', ')}`)
   for (const childProcess of childProcesses) {
     childProcess.stderr.removeAllListeners()

--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -53,13 +53,14 @@ const maybeReportErrorToSentry = (/** @type {unknown} */ err) => {
 
   /** @type {Parameters<Sentry.captureException>[1]} */
   const hint = {}
-  if (typeof err === 'object' && 'details' in err) {
+  if (typeof err === 'object' && 'details' in err && typeof err.details === 'string') {
     // Quoting from https://develop.sentry.dev/sdk/data-handling/
     // > Messages are limited to 8192 characters.
     // > Individual extra data items are limited to 16kB. Total extra data is limited to 256kb.
-    // Let's store the additional details (e.g.full message including stdout && stderr in an extra field
+    // Let's store the additional details (e.g. stdout && stderr) in an extra field
+    const tail = err.details.split(/\n/g).slice(-50).join('\n')
     hint.extra = {
-      details: err.details
+      details: tail
     }
   }
 
@@ -212,25 +213,24 @@ const catchChildProcessExit = async ({
       try {
         await p
       } catch (err) {
-        // When the child process crash, attach the module name & the exit code to the error object
-        throw Object.assign(err, { moduleName: module, exitCode: p.exitCode })
+        // When the child process crash, attach the module name & the exit reason to the error object
+        const exitReason = p.exitCode
+          ? `with exit code ${p.exitCode}`
+          : p.signalCode ? `via signal ${p.signalCode}` : undefined
+        throw Object.assign(err, { moduleName: p.moduleName, exitReason })
       }
     })())
 
     await Promise.race(tasks)
   } catch (err) {
     if (!shouldRestart.get()) {
-      const moduleName = capitalize(err.moduleName) ?? 'Zinnia'
-      const exitCode = err.exitCode ?? '<unknown>'
-      const message = `${moduleName} crashed with exit code ${exitCode}`
+      const moduleName = capitalize(err.moduleName ?? 'Zinnia')
+      const exitReason = err.exitReason ?? 'for unknown reason'
+      const message = `${moduleName} crashed ${exitReason}`
       onActivity({ type: 'error', message })
       const moduleErr = new Error(message, { cause: err })
-      // Detect execa errors, see
-      // https://github.com/sindresorhus/execa?tab=readme-ov-file#execasyncerror
-      // and store the full message including stdout & stder in the top-level `details` property
-      if (err instanceof Error && 'shortMessage' in err && 'originalMessage' in err) {
-        Object.assign(err, { details: err.message })
-      }
+      // Store the full error message including stdout & stder in the top-level `details` property
+      Object.assign(moduleErr, { details: err.message })
       maybeReportErrorToSentry(moduleErr)
       throw err
     }
@@ -245,7 +245,7 @@ const waitForStdioClose = async ({ childProcesses, controller }) => {
   const results = await Promise.all(
     childProcesses.map(childProcess => once(childProcess, 'close'))
   )
-  const codes = results.map(([code]) => code ?? '<no code>')
+  const codes = results.map(([code, signal]) => code || signal || '<no code>')
   console.error(`Zinnia closed all stdio with codes ${codes.join(', ')}`)
   for (const childProcess of childProcesses) {
     childProcess.stderr.removeAllListeners()

--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -53,15 +53,13 @@ const maybeReportErrorToSentry = (/** @type {unknown} */ err) => {
 
   /** @type {Parameters<Sentry.captureException>[1]} */
   const hint = {}
-  // Detect execa errors, see
-  // https://github.com/sindresorhus/execa?tab=readme-ov-file#execasyncerror
-  if (err instanceof Error && 'shortMessage' in err && 'originalMessage' in err) {
+  if (typeof err === 'object' && 'details' in err) {
     // Quoting from https://develop.sentry.dev/sdk/data-handling/
     // > Messages are limited to 8192 characters.
     // > Individual extra data items are limited to 16kB. Total extra data is limited to 256kb.
-    // Let's store the full message including stdout && stderr in an extra field
+    // Let's store the additional details (e.g.full message including stdout && stderr in an extra field
     hint.extra = {
-      details: err.message
+      details: err.details
     }
   }
 
@@ -210,11 +208,30 @@ const catchChildProcessExit = async ({
   onActivity
 }) => {
   try {
-    await Promise.race(childProcesses)
+    const tasks = childProcesses.map(p => (async () => {
+      try {
+        await p
+      } catch (err) {
+        // When the child process crash, attach the module name & the exit code to the error object
+        throw Object.assign(err, { moduleName: module, exitCode: p.exitCode })
+      }
+    })())
+
+    await Promise.race(tasks)
   } catch (err) {
     if (!shouldRestart.get()) {
-      onActivity({ type: 'error', message: 'Zinnia crashed' })
-      maybeReportErrorToSentry(err)
+      const moduleName = capitalize(err.moduleName) ?? 'Zinnia'
+      const exitCode = err.exitCode ?? '<unknown>'
+      const message = `${moduleName} crashed with exit code ${exitCode}`
+      onActivity({ type: 'error', message })
+      const moduleErr = new Error(message, { cause: err })
+      // Detect execa errors, see
+      // https://github.com/sindresorhus/execa?tab=readme-ov-file#execasyncerror
+      // and store the full message including stdout & stder in the top-level `details` property
+      if (err instanceof Error && 'shortMessage' in err && 'originalMessage' in err) {
+        Object.assign(err, { details: err.message })
+      }
+      maybeReportErrorToSentry(moduleErr)
       throw err
     }
   } finally {
@@ -308,7 +325,7 @@ export async function run ({
         }
       }
     )
-    childProcesses.push(childProcess)
+    childProcesses.push(Object.assign(childProcess, { moduleName: module }))
 
     childProcess.stdout.setEncoding('utf-8')
     childProcess.stdout.on('data', data => {


### PR DESCRIPTION
- Add the module name & the exit code to the message
- Remove Zinnia & module main file path from the message

The goal is to allow Sentry to group all errors with the same cause in a single issue.

Add the last 50 lines from the Execa error message (including stdout & stderr) into the `extra` fields sent to Sentry.

This is a follow-up for https://github.com/filecoin-station/core/pull/377
