### PR TITLE
Add custom Sentry grouping for Zinnia exit errors

### DIFF
--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -231,7 +231,13 @@ const catchChildProcessExit = async ({
       const moduleErr = new Error(message, { cause: err })
       // Store the full error message including stdout & stder in the top-level `details` property
       Object.assign(moduleErr, { details: err.message })
-      maybeReportErrorToSentry(moduleErr)
+
+      // Apply a custom rule to force Sentry to group all issues with the same module & exit code
+      // See https://docs.sentry.io/platforms/node/usage/sdk-fingerprinting/#basic-example
+      Sentry.withScope(scope => {
+        scope.setFingerprint([message])
+        maybeReportErrorToSentry(moduleErr)
+      })
       throw err
     }
   } finally {


### PR DESCRIPTION
Before this change, Sentry was creating multiple issue for the same error depending on the inner details (e.g. the module stderr).

After this change, Sentry should look only at the module name and the exit reason (exit code or signal) to determine the group.
