### PR TITLE
Fix main loop not ending properly

### DIFF
--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -139,12 +139,12 @@ async function getContractsWithRetry (provider, abi) {
 }
 
 const runUpdateSourceFilesLoop = async ({
+  controller,
   signal,
   onActivity,
   childProcesses,
   moduleVersionsDir,
-  moduleSourcesDir,
-  shouldRestart
+  moduleSourcesDir
 }) => {
   while (true) {
     const delay = 10 * 60 * 1000 // 10 minutes
@@ -156,10 +156,13 @@ const runUpdateSourceFilesLoop = async ({
       throw err
     }
     try {
-      shouldRestart.set(await updateAllSourceFiles({
+      const shouldRestart = await updateAllSourceFiles({
         moduleVersionsDir,
         moduleSourcesDir
-      }))
+      })
+      if (shouldRestart) {
+        controller.abort()
+      }
     } catch (err) {
       onActivity({
         type: 'error',
@@ -168,7 +171,7 @@ const runUpdateSourceFilesLoop = async ({
       console.error(err)
       maybeReportErrorToSentry(err)
     }
-    if (shouldRestart.get()) {
+    if (signal.aborted) {
       onActivity({
         type: 'info',
         message: 'Updated Zinnia module source code, restarting...'
@@ -176,9 +179,6 @@ const runUpdateSourceFilesLoop = async ({
       for (const childProcess of childProcesses) {
         childProcess.kill()
       }
-      return
-    }
-    if (signal.aborted) {
       return
     }
   }
@@ -205,7 +205,7 @@ const runUpdateContractsLoop = async ({ signal, provider, abi, contracts }) => {
 
 const catchChildProcessExit = async ({
   childProcesses,
-  shouldRestart,
+  signal,
   onActivity
 }) => {
   try {
@@ -223,7 +223,7 @@ const catchChildProcessExit = async ({
 
     await Promise.race(tasks)
   } catch (err) {
-    if (!shouldRestart.get()) {
+    if (!signal.aborted) {
       const moduleName = capitalize(err.moduleName ?? 'Zinnia')
       const exitReason = err.exitReason ?? 'for unknown reason'
       const message = `${moduleName} crashed ${exitReason}`
@@ -356,47 +356,36 @@ export async function run ({
     })
   }
 
-  const shouldRestart = {
-    value: false,
-    set (value) {
-      this.value = value
-    },
-    get () {
-      return this.value
-    }
-  }
   const controller = new AbortController()
   const { signal } = controller
 
   await Promise.all([
     runUpdateSourceFilesLoop({
+      controller,
       signal,
       onActivity,
       childProcesses,
       moduleVersionsDir,
-      moduleSourcesDir,
-      shouldRestart
+      moduleSourcesDir
     }),
     runUpdateContractsLoop({ signal, provider, abi, contracts }),
-    catchChildProcessExit({ childProcesses, shouldRestart, onActivity }),
+    catchChildProcessExit({ childProcesses, onActivity, signal }),
     waitForStdioClose({ childProcesses, controller })
   ])
 
-  if (shouldRestart.get()) {
-    // This infinite recursion has no risk of exceeding the maximum call stack
-    // size, as awaiting promises unwinds the stack
-    return run({
-      FIL_WALLET_ADDRESS,
-      ethAddress,
-      STATE_ROOT,
-      CACHE_ROOT,
-      moduleVersionsDir,
-      moduleSourcesDir,
-      onActivity,
-      onMetrics,
-      isUpdated: true
-    })
-  }
+  // This infinite recursion has no risk of exceeding the maximum call stack
+  // size, as awaiting promises unwinds the stack
+  return run({
+    FIL_WALLET_ADDRESS,
+    ethAddress,
+    STATE_ROOT,
+    CACHE_ROOT,
+    moduleVersionsDir,
+    moduleSourcesDir,
+    onActivity,
+    onMetrics,
+    isUpdated: true
+  })
 }
 
 const jobsCompleted = {}


### PR DESCRIPTION
There are some issues with the zinnia loop end logic. See for example these logs from `core-fly`:

```
Mar 26 15:03:07 core-fly [spark]  ⇣ checking for updates
Mar 26 15:03:08 core-fly [voyager]  ⇣ checking for updates
Mar 26 15:03:08 core-fly [spark]  ⇣ checking for updates
Mar 26 15:03:08 core-fly [voyager]  ⇣ checking for updates
Mar 26 15:03:08 core-fly [voyager]  ✓ no update available
Mar 26 15:03:08 core-fly [spark]  ✓ no update available
Mar 26 15:03:08 core-fly [spark]  ✓ no update available
Mar 26 15:03:08 core-fly [voyager]  ✓ no update available
```

We can see that 2 update loops were running at once, which means that in a previous `run()` invocation the loop should have been aborted, but wasn't.

This PR fixes this by only using one method: `controller.abort()` for aborting, and `controller.signal.aborted` for checking if it was aborted. Previously, `shouldRestart.get()` was used in conjunction with the AbortController, and in some places only one was checked or set.

Should fix issues like https://filecoinproject.slack.com/archives/C03S6LXSRB8/p1711639505087089. This has also been observed on `core-fly`:

```
Mar 26 15:13:09 core-fly [3/26/2024, 2:13:09 PM] INFO  Updated Zinnia module source code, restarting...
```

(no logs following)