### PR TITLE
feat: add moduleName to Sentry issue reports

### DIFF
--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -52,15 +52,18 @@ const maybeReportErrorToSentry = (/** @type {unknown} */ err) => {
   console.error('Reporting the poblem to Sentry for inspection by the Station team.')
 
   /** @type {Parameters<Sentry.captureException>[1]} */
-  const hint = {}
-  if (typeof err === 'object' && 'details' in err && typeof err.details === 'string') {
-    // Quoting from https://develop.sentry.dev/sdk/data-handling/
-    // > Messages are limited to 8192 characters.
-    // > Individual extra data items are limited to 16kB. Total extra data is limited to 256kb.
-    // Let's store the additional details (e.g. stdout && stderr) in an extra field
-    const tail = err.details.split(/\n/g).slice(-50).join('\n')
-    hint.extra = {
-      details: tail
+  const hint = { extra: {} }
+  if (typeof err === 'object') {
+    if ('details' in err && typeof err.details === 'string') {
+      // Quoting from https://develop.sentry.dev/sdk/data-handling/
+      // > Messages are limited to 8192 characters.
+      // > Individual extra data items are limited to 16kB. Total extra data is limited to 256kb.
+      // Let's store the additional details (e.g. stdout && stderr) in an extra field
+      const tail = err.details.split(/\n/g).slice(-50).join('\n')
+      hint.extra.details = tail
+    }
+    if ('moduleName' in err && typeof err.moduleName === 'string') {
+      hint.extra.moduleName = err.moduleName
     }
   }
 


### PR DESCRIPTION
When recording an issue for a module exit event, include the module name in custom tags. I hope this will make issues easier to search and make it easier to merge similar issues.
