### PR TITLE
Fix more zinnia loop issues

### DIFF
--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -146,7 +146,6 @@ const runUpdateSourceFilesLoop = async ({
   controller,
   signal,
   onActivity,
-  childProcesses,
   moduleVersionsDir,
   moduleSourcesDir
 }) => {
@@ -165,7 +164,12 @@ const runUpdateSourceFilesLoop = async ({
         moduleSourcesDir
       })
       if (shouldRestart) {
+        onActivity({
+          type: 'info',
+          message: 'Updated Zinnia module source code, restarting...'
+        })
         controller.abort()
+        return
       }
     } catch (err) {
       onActivity({
@@ -174,16 +178,6 @@ const runUpdateSourceFilesLoop = async ({
       })
       console.error(err)
       maybeReportErrorToSentry(err)
-    }
-    if (signal.aborted) {
-      onActivity({
-        type: 'info',
-        message: 'Updated Zinnia module source code, restarting...'
-      })
-      for (const childProcess of childProcesses) {
-        childProcess.kill()
-      }
-      return
     }
   }
 }
@@ -209,6 +203,7 @@ const runUpdateContractsLoop = async ({ signal, provider, abi, contracts }) => {
 
 const catchChildProcessExit = async ({
   childProcesses,
+  controller,
   signal,
   onActivity
 }) => {
@@ -245,9 +240,7 @@ const catchChildProcessExit = async ({
       throw err
     }
   } finally {
-    for (const childProcess of childProcesses) {
-      childProcess.kill()
-    }
+    controller.abort()
   }
 }
 
@@ -317,6 +310,8 @@ export async function run ({
     }
   }
 
+  const controller = new AbortController()
+  const { signal } = controller
   const childProcesses = []
 
   for (const { module } of ZINNIA_MODULES) {
@@ -332,7 +327,8 @@ export async function run ({
           FIL_WALLET_ADDRESS,
           STATE_ROOT,
           CACHE_ROOT
-        }
+        },
+        signal
       }
     )
     childProcesses.push(Object.assign(childProcess, { moduleName: module }))
@@ -359,9 +355,6 @@ export async function run ({
       onActivity({ type: 'info', message: msg })
     })
   }
-
-  const controller = new AbortController()
-  const { signal } = controller
 
   await Promise.all([
     runUpdateSourceFilesLoop({

--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -356,19 +356,22 @@ export async function run ({
     })
   }
 
-  await Promise.all([
-    runUpdateSourceFilesLoop({
-      controller,
-      signal,
-      onActivity,
-      childProcesses,
-      moduleVersionsDir,
-      moduleSourcesDir
-    }),
-    runUpdateContractsLoop({ signal, provider, abi, contracts }),
-    catchChildProcessExit({ childProcesses, onActivity, signal }),
-    waitForStdioClose({ childProcesses, controller })
-  ])
+  try {
+    await Promise.all([
+      runUpdateSourceFilesLoop({
+        controller,
+        signal,
+        onActivity,
+        moduleVersionsDir,
+        moduleSourcesDir
+      }),
+      runUpdateContractsLoop({ signal, provider, abi, contracts }),
+      catchChildProcessExit({ childProcesses, onActivity, controller, signal }),
+      waitForStdioClose({ childProcesses, controller })
+    ])
+  } finally {
+    controller.abort()
+  }
 
   // This infinite recursion has no risk of exceeding the maximum call stack
   // size, as awaiting promises unwinds the stack

--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -119,8 +119,9 @@ async function getContractAddresses () {
   return revision.value.split('\n').filter(Boolean)
 }
 
-async function getContractsWithRetry (provider, abi) {
+async function getContractsWithRetry ({ provider, abi, signal }) {
   const contractAddresses = await pRetry(getContractAddresses, {
+    signal,
     retries: 10,
     onFailedAttempt: err => {
       console.error(err)
@@ -197,7 +198,7 @@ const runUpdateContractsLoop = async ({ signal, provider, abi, contracts }) => {
       if (err.name === 'AbortError') return
       throw err
     }
-    const newContracts = await getContractsWithRetry(provider, abi)
+    const newContracts = await getContractsWithRetry({ provider, abi, signal })
     contracts.splice(0)
     contracts.push(...newContracts)
     if (signal.aborted) {
@@ -293,7 +294,7 @@ export async function run ({
     )
   )
 
-  const contracts = await getContractsWithRetry(provider, abi)
+  const contracts = await getContractsWithRetry({ provider, abi, signal: null })
   const zinniadExe = getBinaryModuleExecutable({ module: 'zinnia', executable: 'zinniad' })
 
   if (!isUpdated) {


### PR DESCRIPTION
The previous patch wasn't sufficient, core-fly got stuck after this:

<img width="606" alt="Screenshot 2024-04-02 at 16 49 16" src="https://github.com/filecoin-station/core/assets/10247/6c39ec8a-d886-4ae8-94cb-46dbec8d2c2d">

When we threw an error, no clean up happened. This is now fixed. And also, we now let execa kill all child processes through the AbortSignal, which helps tighten up the clean up further.