### PR TITLE
change Voyager crashes into `info`

### DIFF
--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -260,7 +260,7 @@ const catchChildProcessExit = async ({
       const moduleName = capitalize(err.moduleName ?? 'Zinnia')
       const exitReason = err.exitReason ?? 'for unknown reason'
       const message = `${moduleName} crashed ${exitReason}`
-      const type = moduleName === 'Spark' ? 'error' : 'info'
+      const type = err.moduleName === 'voyager' ? 'info' : 'error'
       onActivity({ type, message })
       const moduleErr = new Error(message, { cause: err })
       // Store the full error message including stdout & stder in the top-level `details` property

--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -260,7 +260,8 @@ const catchChildProcessExit = async ({
       const moduleName = capitalize(err.moduleName ?? 'Zinnia')
       const exitReason = err.exitReason ?? 'for unknown reason'
       const message = `${moduleName} crashed ${exitReason}`
-      onActivity({ type: 'error', message })
+      const type = moduleName === 'Spark' ? 'error' : 'info'
+      onActivity({ type, message })
       const moduleErr = new Error(message, { cause: err })
       // Store the full error message including stdout & stder in the top-level `details` property
       Object.assign(moduleErr, { details: err.message })


### PR DESCRIPTION
<img width="1192" alt="Screenshot 2024-04-09 at 16 27 57" src="https://github.com/filecoin-station/core/assets/10247/fce24de0-c6b0-4f1c-9b55-cbab64e600d4">

There's nothing that operators can do about these crashes. This PR changes the activity type into "Info"