### PR TITLE
Fix pipeline types

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,6 @@ jobs:
           node-version: ${{ matrix.node }}
       - run: npm ci --omit=dev
       - run: npm ci
-      - run: npm run test:types
       - run: npm run test:lint
         if: matrix.os != 'windows-latest'
       - run: npm run test:unit

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
           node-version: ${{ matrix.node }}
       - run: npm ci --omit=dev
       - run: npm ci
+      - run: npm run test:types
       - run: npm run test:lint
         if: matrix.os != 'windows-latest'
       - run: npm run test:unit

--- a/package.json
+++ b/package.json
@@ -14,14 +14,14 @@
     "node": ">=18"
   },
   "scripts": {
-    "build": "tsc -p .",
     "format": "prettier --write .",
     "lint": "npm run test:lint",
     "start": "FIL_WALLET_ADDRESS=0x000000000000000000000000000000000000dEaD node ./bin/station.js",
-    "test": "npm run build && npm run test:lint && npm run test:unit",
+    "test": "npm run test:types && npm run test:lint && npm run test:unit",
     "test:lint": "prettier --check . && standard",
+    "test:types": "tsc -p .",
     "test:unit": "mocha",
-    "version": "npm run build && node ./scripts/version.js",
+    "version": "node ./scripts/version.js",
     "postinstall": "node ./scripts/post-install.js",
     "postpublish": "node ./scripts/post-publish.js",
     "release": "np"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "format": "prettier --write .",
     "lint": "npm run test:lint",
     "start": "FIL_WALLET_ADDRESS=0x000000000000000000000000000000000000dEaD node ./bin/station.js",
-    "test": "npm run test:types && npm run test:lint && npm run test:unit",
+    "test": "npm run test:lint && npm run test:unit",
     "test:lint": "prettier --check . && standard",
     "test:types": "tsc -p .",
     "test:unit": "mocha",


### PR DESCRIPTION
Tests are failing locally, but not in CI. This is because we didn't include the `build` step in CI. This PR fixes that. It also then disables it temporarily, so that we can publish new versions of this project again.

@bajtos I wasn't able to figure out the type failures unfortunately :| Do you have an idea?