### PR TITLE
deps: upgrade Zinnia to v0.18.1

### DIFF
--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -10,7 +10,7 @@ import timers from 'node:timers/promises'
 import { join } from 'node:path'
 import * as Name from 'w3name'
 
-const ZINNIA_DIST_TAG = 'v0.17.0'
+const ZINNIA_DIST_TAG = 'v0.18.1'
 const ZINNIA_MODULES = [
   {
     module: 'spark',


### PR DESCRIPTION
https://github.com/filecoin-station/zinnia/releases/tag/v0.18.1

Blocked by:
- #406

Links:
- filecoin-station/roadmap#96
