### PR TITLE
chore: fix TypeScript errors related to `pipeline`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
           node-version: ${{ matrix.node }}
       - run: npm ci --omit=dev
       - run: npm ci
+      - run: npm run test:types
       - run: npm run test:lint
         if: matrix.os != 'windows-latest'
       - run: npm run test:unit
@@ -94,6 +95,6 @@ jobs:
 
       - name: Check | Spark started
         run: docker logs station | grep "Spark started"
-      
+
       - name: Check | Voyager started
         run: docker logs station | grep "Voyager started"

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -84,7 +84,10 @@ export const installBinaryModule = async ({
 
   if (target.asset.endsWith('tar.gz')) {
     await mkdir(outFile, { recursive: true })
-    await pipeline(res.body, tar.x({ C: outFile }))
+    await pipeline(
+      /** @type {any} */(res.body),
+      /** @type {any} */(tar.x({ C: outFile }))
+    )
   } else {
     await mkdir(join(moduleBinaries, module), { recursive: true })
     const parser = unzip.Parse()
@@ -207,7 +210,10 @@ export async function updateSourceFiles ({
     if (entry.type === 'file' || entry.type === 'raw') {
       await mkdir(outDir, { recursive: true })
       // `{ strip: 1 }` tells tar to remove the top-level directory (e.g. `mod-peer-checker-v1.0.0`)
-      await pipeline(entry.content(), tar.x({ strip: 1, C: outDir }))
+      await pipeline(
+        /** @type {any} */(entry.content()),
+        /** @type {any} */(tar.x({ strip: 1, C: outDir }))
+      )
     }
   } catch (err) {
     await rm(outDir, { recursive: true })


### PR DESCRIPTION
- **chore: fix TypeScript errors related to `pipeline`**
- **ci: add TypeScript check to the CI workflow**

This is a follow-up for https://github.com/filecoin-station/core/pull/410