### PR TITLE
ci: run CI for pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,5 +1,11 @@
 name: CI
-on: [push]
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
Change the CI workflow triggers to run for changes pushed to the `main` branch and all pull requests targeting the `main` branch.
