### PR TITLE
ci: drop Node.js 19.x

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        node: ['18', '19', '20', '21']
+        node: ['18', '20', '21']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
The release line 19.x is not supported by the Node.js project anymore.

See https://nodejs.org/en/about/previous-releases

![schedule](https://github.com/filecoin-station/core/assets/1140553/85b2bdab-f6cf-46f8-8f9f-d7297ca45410)

