### PR TITLE
feat: warn user about missing PASSPHRASE

### DIFF
--- a/lib/station-id.js
+++ b/lib/station-id.js
@@ -104,6 +104,15 @@ function parseStoredKeys (json) {
  * @returns {Promise<{publicKey: string, privateKey: string}>}
  */
 async function generateKeypair (keystore, passphrase) {
+  if (!passphrase) {
+    console.warn(`
+*****************************************************************************************
+  The private key of the identity of your Station instance will be stored in plaintext.
+  We strongly recommend you to configure PASSPHRASE environment variable to enable
+  Station to encrypt the private key stored on the filesystem.
+*****************************************************************************************
+`)
+  }
   const keyPair = /** @type {import('node:crypto').webcrypto.CryptoKeyPair} */ (
     /** @type {unknown} */ (
       await subtle.generateKey({ name: 'ED25519' }, true, ['sign', 'verify'])


### PR DESCRIPTION
When creating a new station identity and no PASSPHRASE was provided by the operator, print a warning instructing them to provide one.

Example output:

```
❯ npm start

> @filecoin-station/core@20.2.0 start
> cross-env FIL_WALLET_ADDRESS=0x000000000000000000000000000000000000dEaD STATE_ROOT=.state CACHE_ROOT=.cache node ./bin/station.js


*****************************************************************************************
  The private key of the identity of your Station instance will be stored in plaintext.
  We strongly recommend you to configure PASSPHRASE environment variable to enable
  Station to encrypt the private key stored on the filesystem.
*****************************************************************************************

(node:96209) ExperimentalWarning: The Ed25519 Web Crypto API algorithm is an experimental feature and might change at any time
(Use `node --trace-warnings ...` to show where the warning was created)
Generated a new Station ID: 302a300506032b65700321008bb914b39a475198c1ba95ec70547d342c1b1789d806d975eabeba5f5297dfb2
Meridian contract addresses: 0x8460766Edc62B525fc1FA4D628FC79229dC73031
[25/04/2024, 14:55:05] INFO  Updating source code for Zinnia modules...
```

This is a follow-up for:
- https://github.com/filecoin-station/core/pull/424

cc @PatrickNercessian