### PR TITLE
fix: print station-id logs to stderr

### DIFF
--- a/lib/station-id.js
+++ b/lib/station-id.js
@@ -17,7 +17,7 @@ export async function getStationId ({ secretsDir, passphrase }) {
 
   try {
     const keypair = await loadKeypair(keystore, passphrase)
-    console.log('Loaded Station ID: %s', keypair.publicKey)
+    console.error('Loaded Station ID: %s', keypair.publicKey)
     return keypair
   } catch (err) {
     if (err.code === 'ENOENT' && err.path === keystore) {
@@ -84,7 +84,7 @@ async function tryUpgradePlaintextToCiphertext (passphrase, keystore, maybeCiphe
 
   // re-create the keypair file with encrypted keypair
   await storeKeypair(passphrase, keystore, keypair)
-  console.log('Encrypted the Station ID file using the provided PASSPHRASE.')
+  console.error('Encrypted the Station ID file using the provided PASSPHRASE.')
   return keypair
 }
 /**
@@ -120,7 +120,7 @@ async function generateKeypair (keystore, passphrase) {
   )
   const publicKey = Buffer.from(await subtle.exportKey('spki', keyPair.publicKey)).toString('hex')
   const privateKey = Buffer.from(await subtle.exportKey('pkcs8', keyPair.privateKey)).toString('hex')
-  console.log('Generated a new Station ID:', publicKey)
+  console.error('Generated a new Station ID:', publicKey)
   await storeKeypair(passphrase, keystore, { publicKey, privateKey })
   return { publicKey, privateKey }
 }


### PR DESCRIPTION
stdout is reserved for JSON-formatted activity-log events

The Sentry Issue where I learned about the problem: https://space-meridian.sentry.io/issues/5259340154/?project=6762462&query=is%3Aunresolved&referrer=issue-stream&statsPeriod=7d&stream_index=1&utc=true
