### PR TITLE
Change Docker base image to slim

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20
+FROM node:20-slim
 LABEL org.opencontainers.image.source https://github.com/filecoin-station/core
 USER node
 WORKDIR /usr/src/app


### PR DESCRIPTION
Slim shaves about 400MB off the container when installed. It is always better to have smaller images, especially when installing these at the edge on routers and such.