### PR TITLE
fix pass eth address to zinnia

### DIFF
--- a/commands/station.js
+++ b/commands/station.js
@@ -91,7 +91,7 @@ export const station = async ({ json, experimental }) => {
   const modules = [
     zinniaRuntime.run({
       STATION_ID,
-      FIL_WALLET_ADDRESS,
+      FIL_WALLET_ADDRESS: ethAddress,
       ethAddress,
       STATE_ROOT: join(paths.moduleState, 'zinnia'),
       CACHE_ROOT: join(paths.moduleCache, 'zinnia'),


### PR DESCRIPTION
This way we only get 0x addresses submitted to `{spark,voyager}-api`