### PR TITLE
ci: add Node.js 22, drop 21

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        node: ['18', '20', '21']
+        node: ['18', '20', '22']
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-node@v4


### PR DESCRIPTION
See https://nodejs.org/en/blog/announcements/v22-release-announce and https://twitter.com/_rafaelgss/status/1784932576924164227

> Node.js 21 is now in maintenance mode, which means this release line won't receive any further updates apart from security releases.
