### PR TITLE
Fix zinnia sentry grouping

### DIFF
--- a/bin/station.js
+++ b/bin/station.js
@@ -10,7 +10,7 @@ import * as paths from '../lib/paths.js'
 const pkg = JSON.parse(await fs.readFile(paths.packageJSON, 'utf8'))
 
 Sentry.init({
-  dsn: 'https://0269983069b7f77f9aab04686c3912e4@o1408530.ingest.us.sentry.io/4504792315199488',
+  dsn: 'https://17f2eb5ca47ec493cf427618bf013294@o1408530.ingest.us.sentry.io/4504792315199488',
   release: pkg.version,
   environment: pkg.sentryEnvironment,
   tracesSampleRate: 0.1,

--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -48,8 +48,6 @@ const maybeReportErrorToSentry = (/** @type {unknown} */ err) => {
   if (now - lastCrashReportedAt < 4 /* HOURS */ * 3600_000) return
   lastCrashReportedAt = now
 
-  console.error('Reporting the problem to Sentry for inspection by the Station team.')
-
   /** @type {Parameters<Sentry.captureException>[1]} */
   const hint = { extra: {} }
   if (typeof err === 'object') {
@@ -70,6 +68,7 @@ const maybeReportErrorToSentry = (/** @type {unknown} */ err) => {
     }
   }
 
+  console.error('Reporting the problem to Sentry for inspection by the Station team.')
   Sentry.captureException(err, hint)
 }
 
@@ -242,7 +241,6 @@ const runUpdateRewardsLoop = async ({ signal, contracts, ethAddress, onMetrics }
 const catchChildProcessExit = async ({
   childProcesses,
   controller,
-  signal,
   onActivity
 }) => {
   try {
@@ -260,28 +258,26 @@ const catchChildProcessExit = async ({
 
     await Promise.race(tasks)
   } catch (err) {
-    if (!signal.aborted) {
-      const moduleName = capitalize(err.moduleName ?? 'Zinnia')
-      const exitReason = err.exitReason ?? 'for unknown reason'
-      const message = `${moduleName} crashed ${exitReason}`
-      const isCritical = err.moduleName !== 'voyager'
-      const type = isCritical ? 'error' : 'info'
-      onActivity({ type, message })
+    const moduleName = capitalize(err.moduleName ?? 'Zinnia')
+    const exitReason = err.exitReason ?? 'for unknown reason'
+    const message = `${moduleName} crashed ${exitReason}`
+    const isCritical = err.moduleName !== 'voyager'
+    const type = isCritical ? 'error' : 'info'
+    onActivity({ type, message })
 
-      if (isCritical) {
-        const moduleErr = new Error(message, { cause: err })
-        // Store the full error message including stdout & stder in the top-level `details` property
-        Object.assign(moduleErr, { details: err.message })
+    if (isCritical) {
+      const moduleErr = new Error(message, { cause: err })
+      // Store the full error message including stdout & stder in the top-level `details` property
+      Object.assign(moduleErr, { details: err.message })
 
-        // Apply a custom rule to force Sentry to group all issues with the same module & exit code
-        // See https://docs.sentry.io/platforms/node/usage/sdk-fingerprinting/#basic-example
-        Sentry.withScope(scope => {
-          scope.setFingerprint([message])
-          maybeReportErrorToSentry(moduleErr)
-        })
-      }
-      throw err
+      // Apply a custom rule to force Sentry to group all issues with the same module & exit code
+      // See https://docs.sentry.io/platforms/node/usage/sdk-fingerprinting/#basic-example
+      Sentry.withScope(scope => {
+        scope.setFingerprint([message])
+        maybeReportErrorToSentry(moduleErr)
+      })
     }
+    throw err
   } finally {
     controller.abort()
   }
@@ -422,7 +418,7 @@ export async function run ({
       }),
       runUpdateContractsLoop({ signal, provider, abi, contracts }),
       runUpdateRewardsLoop({ signal, contracts, ethAddress, onMetrics }),
-      catchChildProcessExit({ childProcesses, onActivity, controller, signal })
+      catchChildProcessExit({ childProcesses, onActivity, controller })
     ])
     console.error('Zinnia main loop ended')
   } catch (err) {

--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -258,24 +258,28 @@ const catchChildProcessExit = async ({
 
     await Promise.race(tasks)
   } catch (err) {
-    const moduleName = capitalize(err.moduleName ?? 'Zinnia')
-    const exitReason = err.exitReason ?? 'for unknown reason'
-    const message = `${moduleName} crashed ${exitReason}`
-    const isCritical = err.moduleName !== 'voyager'
-    const type = isCritical ? 'error' : 'info'
-    onActivity({ type, message })
+    if (err.name === 'AbortError') {
+      Object.assign(err, { reportedToSentry: true })
+    } else {
+      const moduleName = capitalize(err.moduleName ?? 'Zinnia')
+      const exitReason = err.exitReason ?? 'for unknown reason'
+      const message = `${moduleName} crashed ${exitReason}`
+      const isCritical = err.moduleName !== 'voyager'
+      const type = isCritical ? 'error' : 'info'
+      onActivity({ type, message })
 
-    if (isCritical) {
-      const moduleErr = new Error(message, { cause: err })
-      // Store the full error message including stdout & stder in the top-level `details` property
-      Object.assign(moduleErr, { details: err.message })
+      if (isCritical) {
+        const moduleErr = new Error(message, { cause: err })
+        // Store the full error message including stdout & stder in the top-level `details` property
+        Object.assign(moduleErr, { details: err.message })
 
-      // Apply a custom rule to force Sentry to group all issues with the same module & exit code
-      // See https://docs.sentry.io/platforms/node/usage/sdk-fingerprinting/#basic-example
-      Sentry.withScope(scope => {
-        scope.setFingerprint([message])
-        maybeReportErrorToSentry(moduleErr)
-      })
+        // Apply a custom rule to force Sentry to group all issues with the same module & exit code
+        // See https://docs.sentry.io/platforms/node/usage/sdk-fingerprinting/#basic-example
+        Sentry.withScope(scope => {
+          scope.setFingerprint([message])
+          maybeReportErrorToSentry(moduleErr)
+        })
+      }
     }
     throw err
   } finally {

--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -51,10 +51,10 @@ const maybeReportErrorToSentry = (/** @type {unknown} */ err) => {
   /** @type {Parameters<Sentry.captureException>[1]} */
   const hint = { extra: {} }
   if (typeof err === 'object') {
-    if ('reportedToSentry' in err && err.reportedToSentry === true) {
+    if ('reportToSentry' in err && err.reportToSentry === false) {
       return
     }
-    Object.assign(err, { reportedToSentry: true })
+    Object.assign(err, { reportToSentry: false })
     if ('details' in err && typeof err.details === 'string') {
       // Quoting from https://develop.sentry.dev/sdk/data-handling/
       // > Messages are limited to 8192 characters.
@@ -259,7 +259,7 @@ const catchChildProcessExit = async ({
     await Promise.race(tasks)
   } catch (err) {
     if (err.name === 'AbortError') {
-      Object.assign(err, { reportedToSentry: true })
+      Object.assign(err, { reportToSentry: false })
     } else {
       const moduleName = capitalize(err.moduleName ?? 'Zinnia')
       const exitReason = err.exitReason ?? 'for unknown reason'


### PR DESCRIPTION
The problem was `if (!signal.aborted)`: We only performed the special Sentry error transformation when a child process exited on its own. When the AbortController was triggered (say because there was a module update), then `signal.aborted` was always `true`, and therefore the special Sentry code didn't run.

This condition was a mistake, and is now removed in this PR. We want to run the code block on every child process exit.