### PR TITLE
feat: exit code 2 when walled failed screening

### DIFF
--- a/commands/station.js
+++ b/commands/station.js
@@ -20,15 +20,19 @@ const moduleNames = [
   'zinnia'
 ]
 
-const panic = msg => {
+/**
+ * @param {string} msg
+ * @param {number} [exitCode]
+ */
+const panic = (msg, exitCode = 1) => {
   console.error(msg)
-  process.exit(1)
+  process.exit(exitCode)
 }
 
 export const station = async ({ json, experimental }) => {
   if (!FIL_WALLET_ADDRESS) panic('FIL_WALLET_ADDRESS required')
   if (FIL_WALLET_ADDRESS.startsWith('f1')) {
-    panic('f1 addresses are currently not supported. Please use an f4 or 0x address')
+    panic('Invalid FIL_WALLET_ADDRESS: f1 addresses are currently not supported. Please use an f4 or 0x address.')
   }
   if (
     !FIL_WALLET_ADDRESS.startsWith('f410') &&
@@ -48,7 +52,7 @@ export const station = async ({ json, experimental }) => {
         console.error('Failed to validate FIL_WALLET_ADDRESS address. Retrying...')
     }
   )
-  if (fetchRes.status === 403) panic('Invalid FIL_WALLET_ADDRESS address')
+  if (fetchRes.status === 403) panic('Invalid FIL_WALLET_ADDRESS address', 2)
   if (!fetchRes.ok) panic('Failed to validate FIL_WALLET_ADDRESS address')
   const ethAddress = FIL_WALLET_ADDRESS.startsWith('0x')
     ? FIL_WALLET_ADDRESS

--- a/test/cli.js
+++ b/test/cli.js
@@ -14,13 +14,19 @@ describe('CLI', () => {
       }))
     })
     it('fails with sanctioned address', async () => {
-      await assert.rejects(execa(station, {
-        env: {
-          STATE_ROOT: getUniqueTempDir(),
-          PASSPHRASE,
-          FIL_WALLET_ADDRESS: '0x1da5821544e25c636c1417ba96ade4cf6d2f9b5a'
-        }
-      }))
+      try {
+        await execa(station, {
+          env: {
+            STATE_ROOT: getUniqueTempDir(),
+            PASSPHRASE,
+            FIL_WALLET_ADDRESS: '0x1da5821544e25c636c1417ba96ade4cf6d2f9b5a'
+          }
+        })
+      } catch (err) {
+        assert.strictEqual(err.exitCode, 2)
+        return
+      }
+      assert.fail('Expected Station Core to return a non-zero exit code')
     })
     it('starts without passphrase in a fresh install', async () => {
       const ps = execa(station, {


### PR DESCRIPTION
When the user provides `FIL_WALLET_ADDRESS` that's rejected by our screening service, return a different exit code to allow Station Desktop to detect this error and apply different error handling.

See https://space-meridian.sentry.io/issues/4996347608/events/7c27f714175449b7b347bbae476151b6/
