### PR TITLE
modules: fix lstat error on `outDir`. Closes #465

### DIFF
--- a/lib/modules.js
+++ b/lib/modules.js
@@ -217,7 +217,6 @@ export async function updateSourceFiles ({
     }
   } catch (err) {
     try {
-      await stat(outDir)
       await rm(outDir, { recursive: true })
     } catch {
       if (err.code !== 'ENOENT') {

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -188,31 +188,43 @@ export async function updateSourceFiles ({
     }
   }
 
-  const reader = await CarReader.fromIterable(res.body)
-  const entries = exporter(cid, {
-    async get (blockCid) {
-      const block = await reader.get(blockCid)
-      try {
-        await validateBlock(block)
-      } catch (err) {
-        throw new Error(`Invalid block ${blockCid} of root ${cid}`, {
-          cause: err
-        })
+  try {
+    const reader = await CarReader.fromIterable(res.body)
+    const entries = exporter(cid, {
+      async get (blockCid) {
+        const block = await reader.get(blockCid)
+        try {
+          await validateBlock(block)
+        } catch (err) {
+          throw new Error(`Invalid block ${blockCid} of root ${cid}`, {
+            cause: err
+          })
+        }
+        return block.bytes
       }
-      return block.bytes
+    })
+    const { value: entry } = await entries.next()
+    assert(entry, `No entries in ${module} archive`)
+    // Depending on size, entries might be packaged as `file` or `raw`
+    // https://github.com/web3-storage/w3up/blob/e8bffe2ee0d3a59a977d2c4b7efe425699424e19/packages/upload-client/src/unixfs.js#L11
+    if (entry.type === 'file' || entry.type === 'raw') {
+      await mkdir(outDir, { recursive: true })
+      // `{ strip: 1 }` tells tar to remove the top-level directory (e.g. `mod-peer-checker-v1.0.0`)
+      await pipeline(
+        /** @type {any} */(entry.content()),
+        /** @type {any} */(tar.x({ strip: 1, C: outDir }))
+      )
     }
-  })
-  const { value: entry } = await entries.next()
-  assert(entry, `No entries in ${module} archive`)
-  // Depending on size, entries might be packaged as `file` or `raw`
-  // https://github.com/web3-storage/w3up/blob/e8bffe2ee0d3a59a977d2c4b7efe425699424e19/packages/upload-client/src/unixfs.js#L11
-  if (entry.type === 'file' || entry.type === 'raw') {
-    await mkdir(outDir, { recursive: true })
-    // `{ strip: 1 }` tells tar to remove the top-level directory (e.g. `mod-peer-checker-v1.0.0`)
-    await pipeline(
-      /** @type {any} */(entry.content()),
-      /** @type {any} */(tar.x({ strip: 1, C: outDir }))
-    )
+  } catch (err) {
+    try {
+      await stat(outDir)
+      await rm(outDir, { recursive: true })
+    } catch {
+      if (err.code !== 'ENOENT') {
+        throw err
+      }
+    }
+    throw err
   }
 
   await setLastSeenModuleCID({ module, cid, moduleVersionsDir })

--- a/lib/modules.js
+++ b/lib/modules.js
@@ -188,36 +188,31 @@ export async function updateSourceFiles ({
     }
   }
 
-  try {
-    const reader = await CarReader.fromIterable(res.body)
-    const entries = exporter(cid, {
-      async get (blockCid) {
-        const block = await reader.get(blockCid)
-        try {
-          await validateBlock(block)
-        } catch (err) {
-          throw new Error(`Invalid block ${blockCid} of root ${cid}`, {
-            cause: err
-          })
-        }
-        return block.bytes
+  const reader = await CarReader.fromIterable(res.body)
+  const entries = exporter(cid, {
+    async get (blockCid) {
+      const block = await reader.get(blockCid)
+      try {
+        await validateBlock(block)
+      } catch (err) {
+        throw new Error(`Invalid block ${blockCid} of root ${cid}`, {
+          cause: err
+        })
       }
-    })
-    const { value: entry } = await entries.next()
-    assert(entry, `No entries in ${module} archive`)
-    // Depending on size, entries might be packaged as `file` or `raw`
-    // https://github.com/web3-storage/w3up/blob/e8bffe2ee0d3a59a977d2c4b7efe425699424e19/packages/upload-client/src/unixfs.js#L11
-    if (entry.type === 'file' || entry.type === 'raw') {
-      await mkdir(outDir, { recursive: true })
-      // `{ strip: 1 }` tells tar to remove the top-level directory (e.g. `mod-peer-checker-v1.0.0`)
-      await pipeline(
-        /** @type {any} */(entry.content()),
-        /** @type {any} */(tar.x({ strip: 1, C: outDir }))
-      )
+      return block.bytes
     }
-  } catch (err) {
-    await rm(outDir, { recursive: true })
-    throw err
+  })
+  const { value: entry } = await entries.next()
+  assert(entry, `No entries in ${module} archive`)
+  // Depending on size, entries might be packaged as `file` or `raw`
+  // https://github.com/web3-storage/w3up/blob/e8bffe2ee0d3a59a977d2c4b7efe425699424e19/packages/upload-client/src/unixfs.js#L11
+  if (entry.type === 'file' || entry.type === 'raw') {
+    await mkdir(outDir, { recursive: true })
+    // `{ strip: 1 }` tells tar to remove the top-level directory (e.g. `mod-peer-checker-v1.0.0`)
+    await pipeline(
+      /** @type {any} */(entry.content()),
+      /** @type {any} */(tar.x({ strip: 1, C: outDir }))
+    )
   }
 
   await setLastSeenModuleCID({ module, cid, moduleVersionsDir })


### PR DESCRIPTION
@bajtos I have finally been able to reproduce the lstat errors that are reported so often. And for me, the only way to recover was this quick fix. I didn't have time to look into it more properly.

Since the diff is indentation heavy, the gist is this: Remove the try/catch that removes `outDir` when the download failed. I don't know why this fixes it, or whether this introduces regressions.

Closes #465