### PR TITLE
station: update enable json-rpc request batching

### DIFF
--- a/commands/station.js
+++ b/commands/station.js
@@ -109,11 +109,7 @@ export const station = async ({ json, experimental }) => {
     'Authorization',
     'Bearer RXQ2SKH/BVuwN7wisZh3b5uXStGPj1JQIrIWD+rxF0Y='
   )
-  const provider = new ethers.JsonRpcProvider(
-    fetchRequest,
-    null,
-    { batchMaxCount: 1 }
-  )
+  const provider = new ethers.JsonRpcProvider(fetchRequest)
   const abi = JSON.parse(
     await fs.readFile(
       fileURLToPath(new URL('../lib/abi.json', import.meta.url)),


### PR DESCRIPTION
Request batching is supported by Glif nodes now, and we were advised to enable it.