### PR TITLE
contracts: update wait after fetch

### DIFF
--- a/lib/contracts.js
+++ b/lib/contracts.js
@@ -10,6 +10,10 @@ const {
 
 export const runUpdateContractsLoop = async ({ provider, abi, contracts }) => {
   while (true) {
+    const newContracts = await getContractsWithRetry({ provider, abi })
+    contracts.splice(0)
+    contracts.push(...newContracts)
+
     const delay = 10 * 60 * 1000 // 10 minutes
     const jitter = Math.random() * 20_000 - 10_000 // +- 10 seconds
     try {
@@ -18,9 +22,6 @@ export const runUpdateContractsLoop = async ({ provider, abi, contracts }) => {
       if (err.name === 'AbortError') return
       throw err
     }
-    const newContracts = await getContractsWithRetry({ provider, abi })
-    contracts.splice(0)
-    contracts.push(...newContracts)
   }
 }
 

--- a/lib/contracts.js
+++ b/lib/contracts.js
@@ -9,6 +9,7 @@ const {
 } = process.env
 
 export const runUpdateContractsLoop = async ({ provider, abi, contracts }) => {
+  await timers.setTimeout(2_000)
   while (true) {
     const newContracts = await getContractsWithRetry({ provider, abi })
     contracts.splice(0)

--- a/lib/contracts.js
+++ b/lib/contracts.js
@@ -25,7 +25,7 @@ export const runUpdateContractsLoop = async ({ provider, abi, contracts, onActiv
       })
     }
 
-    const delay = DELAY_IN_MINUTES * 60 * 1000 // 10 minutes
+    const delay = DELAY_IN_MINUTES * 60 * 1000
     const jitter = Math.random() * 20_000 - 10_000 // +- 10 seconds
     try {
       await timers.setTimeout(delay + jitter)

--- a/lib/contracts.js
+++ b/lib/contracts.js
@@ -8,6 +8,8 @@ const {
   CONTRACT_ADDRESSES_IPNS_KEY = 'k51qzi5uqu5dmaqrefqazad0ca8b24fb79zlacfjw2awdt5gjf2cr6jto5jyqe'
 } = process.env
 
+const DELAY_IN_MINUTES = 10
+
 export const runUpdateContractsLoop = async ({ provider, abi, contracts, onActivity }) => {
   await timers.setTimeout(2_000)
   while (true) {
@@ -19,11 +21,11 @@ export const runUpdateContractsLoop = async ({ provider, abi, contracts, onActiv
       console.error('Failed to update the list of contract addresses. Will retry later.', err)
       onActivity({
         type: 'error',
-        message: `Cannot update scheduled rewards. Will retry in ${delayInMinutes} minutes.`
+        message: `Cannot update scheduled rewards. Will retry in ${DELAY_IN_MINUTES} minutes.`
       })
     }
 
-    const delay = 10 * 60 * 1000 // 10 minutes
+    const delay = DELAY_IN_MINUTES * 60 * 1000 // 10 minutes
     const jitter = Math.random() * 20_000 - 10_000 // +- 10 seconds
     try {
       await timers.setTimeout(delay + jitter)


### PR DESCRIPTION
Now that the contract update loop is decoupled from modules crashing, we can fetch updates immediately without needing to worry about ddosing w3name