### PR TITLE
feat: allow-list files included in the npm package

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,1 +1,0 @@
-modules

--- a/package.json
+++ b/package.json
@@ -61,5 +61,11 @@
     "w3name": "^1.0.8",
     "yargs": "^17.7.1"
   },
+  "files": [
+    "bin",
+    "commands",
+    "dist",
+    "lib"
+  ],
   "sentryEnvironment": "development"
 }


### PR DESCRIPTION
See the discussion in https://github.com/filecoin-station/desktop/pull/1546

We shouldn't be shipping local state & cache files created on the developer
machine. We also don't need to ship tests, GitHub configuration and more.

List of files packaged by the new package config:

```
npm notice
npm notice 📦  @filecoin-station/core@20.6.2
npm notice === Tarball Contents ===
npm notice 12.6kB LICENSE.md
npm notice 6.1kB  README.md
npm notice 1.1kB  bin/station.js
npm notice 4.9kB  commands/station.js
npm notice 68B    dist/bin/station.d.ts
npm notice 111B   dist/bin/station.d.ts.map
npm notice 155B   dist/commands/activity.d.ts
npm notice 132B   dist/commands/activity.d.ts.map
npm notice 224B   dist/commands/index.d.ts
npm notice 112B   dist/commands/index.d.ts.map
npm notice 151B   dist/commands/logs.d.ts
npm notice 124B   dist/commands/logs.d.ts.map
npm notice 157B   dist/commands/metrics.d.ts
npm notice 129B   dist/commands/metrics.d.ts.map
npm notice 144B   dist/commands/station.d.ts
npm notice 130B   dist/commands/station.d.ts.map
npm notice 984B   dist/index.d.ts
npm notice 269B   dist/index.d.ts.map
npm notice 866B   dist/lib/activity.d.ts
npm notice 375B   dist/lib/activity.d.ts.map
npm notice 340B   dist/lib/bacalhau.d.ts
npm notice 178B   dist/lib/bacalhau.d.ts.map
npm notice 182B   dist/lib/contracts.d.ts
npm notice 128B   dist/lib/contracts.d.ts.map
npm notice 937B   dist/lib/log.d.ts
npm notice 335B   dist/lib/log.d.ts.map
npm notice 1.1kB  dist/lib/metrics.d.ts
npm notice 403B   dist/lib/metrics.d.ts.map
npm notice 612B   dist/lib/modules.d.ts
npm notice 158B   dist/lib/modules.d.ts.map
npm notice 656B   dist/lib/paths.d.ts
npm notice 168B   dist/lib/paths.d.ts.map
npm notice 276B   dist/lib/rewards.d.ts
npm notice 258B   dist/lib/rewards.d.ts.map
npm notice 710B   dist/lib/saturn-node.d.ts
npm notice 280B   dist/lib/saturn-node.d.ts.map
npm notice 821B   dist/lib/station-id.d.ts
npm notice 400B   dist/lib/station-id.d.ts.map
npm notice 291B   dist/lib/telemetry.d.ts
npm notice 153B   dist/lib/telemetry.d.ts.map
npm notice 120B   dist/lib/util.d.ts
npm notice 115B   dist/lib/util.d.ts.map
npm notice 545B   dist/lib/zinnia.d.ts
npm notice 145B   dist/lib/zinnia.d.ts.map
npm notice 73B    dist/scripts/post-install.d.ts
npm notice 125B   dist/scripts/post-install.d.ts.map
npm notice 73B    dist/scripts/post-publish.d.ts
npm notice 125B   dist/scripts/post-publish.d.ts.map
npm notice 68B    dist/scripts/version.d.ts
npm notice 115B   dist/scripts/version.d.ts.map
npm notice 8.7kB  lib/abi.json
npm notice 928B   lib/activity.js
npm notice 2.1kB  lib/contracts.js
npm notice 2.6kB  lib/metrics.js
npm notice 6.6kB  lib/modules.js
npm notice 2.0kB  lib/paths.js
npm notice 1.1kB  lib/rewards.js
npm notice 7.3kB  lib/station-id.js
npm notice 3.3kB  lib/telemetry.js
npm notice 11.3kB lib/zinnia.js
npm notice 2.0kB  package.json
npm notice 88B    scripts/post-install.js
npm notice 467B   scripts/post-publish.js
npm notice 352B   scripts/version.js
npm notice === Tarball Details ===
npm notice name:          @filecoin-station/core
npm notice version:       20.6.2
npm notice filename:      filecoin-station-core-20.6.2.tgz
npm notice package size:  26.5 kB
npm notice unpacked size: 87.6 kB
npm notice shasum:        927b04e68690baecf38ccf5fbe1a2a3cbd9a4ebd
npm notice integrity:     sha512-syShLDVf8vlj/[...]+xAfLseQBiJQg==
npm notice total files:   64
npm notice
```
