### PR TITLE
docs: update Node.js version on Debian

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ On a fresh [Ubuntu](https://ubuntu.com/) machine:
 
 ```bash
 # Install node.js
-$ curl -fsSL https://deb.nodesource.com/setup_18.x | sudo -E bash - &&\
+$ curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash - &&\
 sudo apt-get install -y nodejs
 
 # Install core


### PR DESCRIPTION
Update the instructions to use Node.js 20.x (was 18.x). 

I did not test the new instructions on a Debian machine, but I did verify that the new URL exists and returns a script that looks legitimate.