### PR TITLE
Rotate Sentry token

### DIFF
--- a/bin/station.js
+++ b/bin/station.js
@@ -10,7 +10,7 @@ import * as paths from '../lib/paths.js'
 const pkg = JSON.parse(await fs.readFile(paths.packageJSON, 'utf8'))
 
 Sentry.init({
-  dsn: 'https://3b1d31e8f060624bb21a70142f53a56e@o1408530.ingest.us.sentry.io/4504792315199488',
+  dsn: 'https://c21b3ce464c161f63d32fc64be84477a@o1408530.ingest.us.sentry.io/4504792315199488',
   release: pkg.version,
   environment: pkg.sentryEnvironment,
   tracesSampleRate: 0.1,


### PR DESCRIPTION
The most frequently submitted error atm is `Command was canceled: /usr/src/app/modules/zinnia/zinniad voyager/main.js`, which won't happen on current Core releases