### PR TITLE
deps: bump Zinnia from 0.20.1 to 0.20.2

### DIFF
--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -6,7 +6,7 @@ import pRetry from 'p-retry'
 import timers from 'node:timers/promises'
 import { join } from 'node:path'
 
-const ZINNIA_DIST_TAG = 'v0.20.1'
+const ZINNIA_DIST_TAG = 'v0.20.2'
 const ZINNIA_MODULES = [
   {
     module: 'spark',


### PR DESCRIPTION
Bump [zinnia](https://github.com/filecoin-station/zinnia) from 0.20.1 to 0.20.2.
- [Release notes](https://github.com/filecoin-station/zinnia/releases/v0.20.2)
- [Commits](https://github.com/filecoin-station/zinnia/compare/v0.20.1...v0.20.2)
