### PR TITLE
fix redundant exit message

### DIFF
--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -163,6 +163,7 @@ const catchChildProcessExit = async ({
     const tasks = childProcesses.map(p => (async () => {
       try {
         await p
+        onActivity({ type: 'info', message: `${capitalize(module)} exited` })
       } catch (err) {
         // When the child process crash, attach the module name & the exit reason to the error object
         const exitReason = p.exitCode
@@ -293,12 +294,6 @@ export async function run ({
     childProcess.stderr.on('data', data => {
       resetTimeout()
       process.stderr.write(data)
-    })
-
-    childProcess.on('exit', (code, signal) => {
-      const exitReason = signal ? `via signal ${signal}` : `with code: ${code}`
-      const msg = `${capitalize(module)} exited ${exitReason}`
-      onActivity({ type: 'info', message: msg })
     })
   }
 


### PR DESCRIPTION
Remove the `exit` event handler which would create duplicate activity events on a crash.