### PR TITLE
zinnia: remove logging retried operations to Sentry

### DIFF
--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -93,7 +93,6 @@ const updateAllSourceFiles = async ({
               console.error(err)
               const msg = `Failed to download ${module} source. Retrying...`
               console.error(msg)
-              maybeReportErrorToSentry(new Error(msg, { cause: err }))
               if (String(err).includes('You are being rate limited')) {
                 const delaySeconds = 30 + (Math.random() * 60)
                 // Don't DDOS the w3name services


### PR DESCRIPTION
When the overall operation failed it will still be logged.