### PR TITLE
fix: don't report SIGTERM & friends to Sentry

### DIFF
--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -190,8 +190,10 @@ const catchChildProcessExit = async ({
       if (err.signalCode && ['SIGTERM', 'SIGKILL', 'SIGINT'].includes(err.signalCode)) {
         // These signal codes are triggered when somebody terminates the process from outside.
         // It's not a problem in Zinnia, there is nothing we can do about this.
-        // Don't report this error to Sentry.
-        Object.assign(err, { reportToSentry: false })
+        // Don't report this error to Sentry and don't print the stack trace to stderr,
+        // treat this as a regular exit (successful completion of the process).
+        // (Note that this event has been already logged via `onActivity()` call above.)
+        return
       } else {
         // Apply a custom rule to force Sentry to group all issues with the same module & exit code
         // See https://docs.sentry.io/platforms/node/usage/sdk-fingerprinting/#basic-example
@@ -200,6 +202,7 @@ const catchChildProcessExit = async ({
           maybeReportErrorToSentry(moduleErr)
         })
       }
+      throw err
     }
   } finally {
     controller.abort()

--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -169,7 +169,7 @@ const catchChildProcessExit = async ({
         const exitReason = p.exitCode
           ? `with exit code ${p.exitCode}`
           : p.signalCode ? `via signal ${p.signalCode}` : undefined
-        throw Object.assign(err, { moduleName: p.moduleName, exitReason })
+        throw Object.assign(err, { moduleName: p.moduleName, exitReason, signalCode: p.signalCode })
       }
     })())
 
@@ -187,14 +187,20 @@ const catchChildProcessExit = async ({
       // Store the full error message including stdout & stder in the top-level `details` property
       Object.assign(moduleErr, { details: err.message })
 
-      // Apply a custom rule to force Sentry to group all issues with the same module & exit code
-      // See https://docs.sentry.io/platforms/node/usage/sdk-fingerprinting/#basic-example
-      Sentry.withScope(scope => {
-        scope.setFingerprint([message])
-        maybeReportErrorToSentry(moduleErr)
-      })
+      if (err.signalCode && ['SIGTERM', 'SIGKILL', 'SIGINT'].includes(err.signalCode)) {
+        // These signal codes are triggered when somebody terminates the process from outside.
+        // It's not a problem in Zinnia, there is nothing we can do about this.
+        // Don't report this error to Sentry.
+        Object.assign(err, { reportToSentry: false })
+      } else {
+        // Apply a custom rule to force Sentry to group all issues with the same module & exit code
+        // See https://docs.sentry.io/platforms/node/usage/sdk-fingerprinting/#basic-example
+        Sentry.withScope(scope => {
+          scope.setFingerprint([message])
+          maybeReportErrorToSentry(moduleErr)
+        })
+      }
     }
-    throw err
   } finally {
     controller.abort()
   }

--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -202,8 +202,8 @@ const catchChildProcessExit = async ({
           maybeReportErrorToSentry(moduleErr)
         })
       }
-      throw err
     }
+    throw err
   } finally {
     controller.abort()
   }


### PR DESCRIPTION
When Zinniad is killed via SIGTERM/SIGKILL/SIGINT, don't report the error to Sentry.

These signal codes are triggered when somebody terminates the process from outside. It's not a problem in Zinnia, there is nothing we can do about this.

Before:

```
ERROR Spark crashed via signal SIGTERM
Reporting the problem to Sentry for inspection by the Station team.
Zinnia main loop ended
Starting zinniad with config CliArgs { /* ... */ }
```

After:

```
ERROR Spark crashed via signal SIGTERM
Zinnia main loop ended
Starting zinniad with config CliArgs { /* ... */ }
```

The Sentry issue:
- https://space-meridian.sentry.io/issues/5098171677/
