### PR TITLE
deps: bump Zinnia from 0.20.3 to 0.20.3

### DIFF
--- a/lib/zinnia.js
+++ b/lib/zinnia.js
@@ -6,7 +6,7 @@ import pRetry from 'p-retry'
 import timers from 'node:timers/promises'
 import { join } from 'node:path'
 
-const ZINNIA_DIST_TAG = 'v0.20.2'
+const ZINNIA_DIST_TAG = 'v0.20.3'
 const ZINNIA_MODULES = [
   {
     module: 'spark',


### PR DESCRIPTION
Bump [zinnia](https://github.com/filecoin-station/zinnia) to 0.20.3.
- [Release notes](https://github.com/filecoin-station/zinnia/releases/v0.20.3)
- [Commits](https://github.com/filecoin-station/zinnia/compare/v0.20.2...v0.20.3)

Bring in the following fix
- https://github.com/filecoin-station/zinnia/pull/593

See also
- https://github.com/filecoin-station/core/issues/583

