### PR TITLE
modules: ensure main file also exists

### DIFF
--- a/lib/modules.js
+++ b/lib/modules.js
@@ -147,7 +147,7 @@ export async function updateSourceFiles ({
   const isUpdate = lastSeenCID !== cid
   if (!isUpdate) {
     try {
-      await stat(outDir)
+      await stat(join(outDir, 'main.js'))
       console.error(`[${module}]  ✓ no update available`)
       return false
     } catch (err) {


### PR DESCRIPTION
Trying to fix reported cases of `sources/spark/main.js` missing, while `sources/spark` is there.

This is the same path we're checking below - only if the main file `main.js` exists, consider the module as functional. This is still not great but should fix some cases. In the future, use hashes to check validity of _all_ files on disk.